### PR TITLE
fix: add missing Headline and SubHeadline typography styles

### DIFF
--- a/src/WayfarerMobile/Shared/Styles/Typography.xaml
+++ b/src/WayfarerMobile/Shared/Styles/Typography.xaml
@@ -23,6 +23,20 @@
         <Setter Property="FontFamily" Value="OpenSansSemibold" />
     </Style>
 
+    <!-- Shorthand headline style (alias for Headline2) -->
+    <Style x:Key="Headline" TargetType="Label">
+        <Setter Property="FontSize" Value="24" />
+        <Setter Property="FontAttributes" Value="Bold" />
+        <Setter Property="FontFamily" Value="OpenSansSemibold" />
+    </Style>
+
+    <!-- SubHeadline Style -->
+    <Style x:Key="SubHeadline" TargetType="Label">
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontAttributes" Value="Bold" />
+        <Setter Property="FontFamily" Value="OpenSansSemibold" />
+    </Style>
+
     <!-- Body Styles -->
     <Style x:Key="Body1" TargetType="Label">
         <Setter Property="FontSize" Value="16" />


### PR DESCRIPTION
## Summary
- Added `Headline` and `SubHeadline` styles to `Typography.xaml`
- These styles were referenced in TimelinePage, GroupsPage, and other pages but not defined
- Missing styles caused XAML pages to fail rendering (appear blank)

## Changes
- `Typography.xaml`: Added 2 new Label styles

## Test plan
- [ ] Verify TimelinePage loads and displays content
- [ ] Verify GroupsPage loads and displays content
- [ ] Check all pages that use Headline/SubHeadline styles

Fixes #1