### PR TITLE
feat: add cache settings and queue management controls

### DIFF
--- a/src/WayfarerMobile.Core/Interfaces/ISettingsService.cs
+++ b/src/WayfarerMobile.Core/Interfaces/ISettingsService.cs
@@ -78,7 +78,7 @@ public interface ISettingsService
     /// <summary>
     /// Prefetch radius in tiles for live cache around user location.
     /// Radius of N means (2N+1)x(2N+1) grid of tiles per zoom level.
-    /// Default: 5 (11x11 grid). Range: 1-9 tiles.
+    /// Default: 5 (11x11 grid). Range: 1-10 tiles.
     /// </summary>
     int LiveCachePrefetchRadius { get; set; }
 

--- a/src/WayfarerMobile/Data/Services/DatabaseService.cs
+++ b/src/WayfarerMobile/Data/Services/DatabaseService.cs
@@ -291,6 +291,19 @@ public class DatabaseService : IAsyncDisposable
     }
 
     /// <summary>
+    /// Clears all pending locations from the queue.
+    /// </summary>
+    /// <returns>The number of locations deleted.</returns>
+    public async Task<int> ClearPendingQueueAsync()
+    {
+        await EnsureInitializedAsync();
+
+        return await _database!.ExecuteAsync(
+            "DELETE FROM QueuedLocations WHERE SyncStatus = ?",
+            (int)SyncStatus.Pending);
+    }
+
+    /// <summary>
     /// Gets all locations for a specific date.
     /// </summary>
     /// <param name="date">The date to retrieve locations for.</param>

--- a/src/WayfarerMobile/Services/SettingsService.cs
+++ b/src/WayfarerMobile/Services/SettingsService.cs
@@ -273,12 +273,12 @@ public class SettingsService : ISettingsService
     /// <summary>
     /// Prefetch radius in tiles for live cache around user location.
     /// Radius of N means (2N+1)x(2N+1) grid of tiles per zoom level.
-    /// Default: 5 (11x11 grid). Range: 1-9 tiles.
+    /// Default: 5 (11x11 grid). Range: 1-10 tiles.
     /// </summary>
     public int LiveCachePrefetchRadius
     {
         get => Preferences.Get(KeyLiveCachePrefetchRadius, 5);
-        set => Preferences.Set(KeyLiveCachePrefetchRadius, Math.Clamp(value, 1, 9));
+        set => Preferences.Set(KeyLiveCachePrefetchRadius, Math.Clamp(value, 1, 10));
     }
 
     /// <summary>

--- a/src/WayfarerMobile/Views/SettingsPage.xaml
+++ b/src/WayfarerMobile/Views/SettingsPage.xaml
@@ -252,6 +252,151 @@
                 </sfExpander:SfExpander.Content>
             </sfExpander:SfExpander>
 
+            <!-- Cache Settings Section -->
+            <sfExpander:SfExpander IsExpanded="False">
+                <sfExpander:SfExpander.Header>
+                    <Grid HeightRequest="48" Padding="10,0">
+                        <Label Text="Cache Settings"
+                               FontSize="16"
+                               FontAttributes="Bold"
+                               VerticalOptions="Center" />
+                    </Grid>
+                </sfExpander:SfExpander.Header>
+                <sfExpander:SfExpander.Content>
+                    <VerticalStackLayout Padding="15" Spacing="15">
+                        <!-- Prefetch Radius Slider -->
+                        <VerticalStackLayout Spacing="8">
+                            <Grid ColumnDefinitions="*,Auto">
+                                <Label Text="Prefetch Radius"
+                                       FontSize="14"
+                                       Grid.Column="0" />
+                                <Label Text="{Binding PrefetchRadiusGridSize}"
+                                       FontSize="14"
+                                       FontAttributes="Bold"
+                                       Grid.Column="1" />
+                            </Grid>
+                            <Slider Minimum="1"
+                                    Maximum="10"
+                                    Value="{Binding LiveCachePrefetchRadius}" />
+                            <Grid ColumnDefinitions="Auto,*,Auto">
+                                <Label Text="1"
+                                       FontSize="10"
+                                       TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray400}}"
+                                       Grid.Column="0" />
+                                <Label Text="{Binding LiveCachePrefetchRadius}"
+                                       FontSize="14"
+                                       FontAttributes="Bold"
+                                       HorizontalOptions="Center"
+                                       Grid.Column="1" />
+                                <Label Text="10"
+                                       FontSize="10"
+                                       TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray400}}"
+                                       Grid.Column="2" />
+                            </Grid>
+                            <Label FontSize="11"
+                                   TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray400}}"
+                                   Text="Controls how many map tiles are downloaded around your location. Higher values give better offline coverage but use more data and storage.&#x0a;&#x0a;• Radius 1: ~10 MB, 3×3 tiles, ~1 km coverage&#x0a;• Radius 5: ~70 MB, 11×11 tiles, ~9 km coverage&#x0a;• Radius 10: ~280 MB, 21×21 tiles, ~17 km coverage&#x0a;&#x0a;Cached tiles are reused (LRU) - moving nearby won't re-download." />
+                        </VerticalStackLayout>
+
+                        <BoxView HeightRequest="1"
+                                 Color="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray700}}" />
+
+                        <!-- Live Cache Size -->
+                        <VerticalStackLayout Spacing="8">
+                            <Label Text="Live Cache Size"
+                                   FontSize="14" />
+                            <Grid ColumnDefinitions="*,80">
+                                <Slider Minimum="100"
+                                        Maximum="2000"
+                                        Value="{Binding MaxLiveCacheSizeMB}"
+                                        Grid.Column="0" />
+                                <Label Text="{Binding MaxLiveCacheSizeMB, StringFormat='{0} MB'}"
+                                       FontSize="14"
+                                       FontAttributes="Bold"
+                                       HorizontalOptions="End"
+                                       VerticalOptions="Center"
+                                       Grid.Column="1" />
+                            </Grid>
+                            <Label Text="Maximum storage for tiles from map browsing. Old tiles are automatically removed when limit is reached."
+                                   FontSize="11"
+                                   TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray400}}" />
+                        </VerticalStackLayout>
+
+                        <BoxView HeightRequest="1"
+                                 Color="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray700}}" />
+
+                        <!-- Trip Cache Size -->
+                        <VerticalStackLayout Spacing="8">
+                            <Label Text="Trip Cache Size"
+                                   FontSize="14" />
+                            <Grid ColumnDefinitions="*,80">
+                                <Slider Minimum="500"
+                                        Maximum="5000"
+                                        Value="{Binding MaxTripCacheSizeMB}"
+                                        Grid.Column="0" />
+                                <Label Text="{Binding MaxTripCacheSizeMB, StringFormat='{0} MB'}"
+                                       FontSize="14"
+                                       FontAttributes="Bold"
+                                       HorizontalOptions="End"
+                                       VerticalOptions="Center"
+                                       Grid.Column="1" />
+                            </Grid>
+                            <Label Text="Maximum storage for downloaded trip tiles. These are preserved longer for offline trip navigation."
+                                   FontSize="11"
+                                   TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray400}}" />
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </sfExpander:SfExpander.Content>
+            </sfExpander:SfExpander>
+
+            <!-- Location Queue Section -->
+            <sfExpander:SfExpander IsExpanded="False">
+                <sfExpander:SfExpander.Header>
+                    <Grid HeightRequest="48" Padding="10,0">
+                        <Label Text="Location Queue"
+                               FontSize="16"
+                               FontAttributes="Bold"
+                               VerticalOptions="Center" />
+                    </Grid>
+                </sfExpander:SfExpander.Header>
+                <sfExpander:SfExpander.Content>
+                    <VerticalStackLayout Padding="15" Spacing="15">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <VerticalStackLayout Grid.Column="0">
+                                <Label Text="Pending Locations"
+                                       FontSize="14" />
+                                <Label Text="Locations waiting to sync to server"
+                                       FontSize="12"
+                                       TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray400}}" />
+                            </VerticalStackLayout>
+                            <Label Text="{Binding PendingQueueCount}"
+                                   FontSize="20"
+                                   FontAttributes="Bold"
+                                   VerticalOptions="Center"
+                                   Grid.Column="1" />
+                        </Grid>
+
+                        <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                            <Button Text="Refresh"
+                                    Command="{Binding RefreshQueueCountCommand}"
+                                    Style="{StaticResource DarkButton}"
+                                    HeightRequest="40"
+                                    Grid.Column="0" />
+                            <Button Text="Clear Queue"
+                                    Command="{Binding ClearQueueCommand}"
+                                    IsEnabled="{Binding IsClearingQueue, Converter={StaticResource InvertedBoolConverter}}"
+                                    Style="{StaticResource DangerButton}"
+                                    HeightRequest="40"
+                                    Grid.Column="1" />
+                        </Grid>
+
+                        <Label Text="Warning: Clearing the queue will permanently delete locations that haven't been synced to the server."
+                               FontSize="11"
+                               TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray400}}" />
+                    </VerticalStackLayout>
+                </sfExpander:SfExpander.Content>
+            </sfExpander:SfExpander>
+
             <!-- Appearance Section -->
             <sfExpander:SfExpander IsExpanded="True">
                 <sfExpander:SfExpander.Header>


### PR DESCRIPTION
## Summary
Added comprehensive cache management and queue controls to the Settings page:

- **Prefetch Radius Slider (1-10)**: Controls tile prefetch area with detailed help text
  - Shows grid size (e.g., "11×11 tiles")
  - Explains storage/data tradeoffs for radius 1, 5, and 10
  - Notes LRU cache reuse behavior

- **Live Cache Size (100-2000 MB)**: Controls max storage for map browsing tiles

- **Trip Cache Size (500-5000 MB)**: Controls max storage for downloaded trip tiles

- **Location Queue Management**:
  - Shows pending location count
  - Refresh button to update count
  - Clear Queue button with confirmation dialog

## Changes
- `ISettingsService.cs`: Updated prefetch radius range from 1-9 to 1-10
- `SettingsService.cs`: Updated validation for new range
- `DatabaseService.cs`: Added `ClearPendingQueueAsync()` method
- `SettingsViewModel.cs`: Added cache properties, queue count, and commands
- `SettingsPage.xaml`: Added Cache Settings and Location Queue sections

## Test plan
- [ ] Verify prefetch radius slider works 1-10
- [ ] Verify grid size label updates dynamically
- [ ] Verify cache size sliders persist values
- [ ] Verify queue count displays correctly
- [ ] Verify clear queue shows confirmation and clears

Fixes #2