### PR TITLE
refactor: centralize tile cache zoom levels (8-17)

### DIFF
--- a/src/WayfarerMobile/Services/TileCache/CacheOverlayService.cs
+++ b/src/WayfarerMobile/Services/TileCache/CacheOverlayService.cs
@@ -88,8 +88,8 @@ public class CacheOverlayService
             _overlayLayer = new WritableLayer { Name = CacheOverlayLayerName, Style = null };
             _labelsLayer = new WritableLayer { Name = CacheLabelsLayerName, Style = null };
 
-            // Zoom levels to check
-            var zoomLevels = new[] { 15, 14, 16, 13, 12, 11, 10, 17 };
+            // Use centralized zoom levels (8-17)
+            var zoomLevels = TileCacheConstants.AllZoomLevels;
 
             // Calculate all coverages in parallel for speed (direct file checks, no DB)
             var coverageTasks = zoomLevels.Select(zoom =>
@@ -312,9 +312,11 @@ public class CacheOverlayService
 
     private static double GetRadiusForZoom(int zoom)
     {
-        // Radius decreases with higher zoom levels (covers all prefetch zoom levels 10-17)
+        // Radius decreases with higher zoom levels (covers all prefetch zoom levels 8-17)
         return zoom switch
         {
+            8 => 12000,
+            9 => 9000,
             10 => 6000,
             11 => 4500,
             12 => 3000,

--- a/src/WayfarerMobile/Services/TileCache/CacheStatusService.cs
+++ b/src/WayfarerMobile/Services/TileCache/CacheStatusService.cs
@@ -22,12 +22,7 @@ public class CacheStatusService
     private DetailedCacheInfo? _lastDetailedInfo;
     private readonly object _statusLock = new();
 
-    // Zoom levels ordered by importance (matches LiveTileCacheService prefetch order)
-    // Quick check uses crucial 3: current view (15), one up (14), one down (16)
-    private static readonly int[] QuickCheckZoomLevels = { 15, 14, 16 };
-
-    // Full check uses all 8 levels for parity with prefetch
-    private static readonly int[] FullCheckZoomLevels = { 15, 14, 16, 13, 12, 11, 10, 17 };
+    // Use centralized zoom level constants for consistency across services
 
     // Debounce: only check every 30 seconds or 100m movement
     private static readonly TimeSpan MinCheckInterval = TimeSpan.FromSeconds(30);
@@ -167,7 +162,7 @@ public class CacheStatusService
                 tripDirs = Directory.GetDirectories(_tripCacheDirectory);
             }
 
-            foreach (var zoom in QuickCheckZoomLevels)
+            foreach (var zoom in TileCacheConstants.QuickCheckZoomLevels)
             {
                 var (centerX, centerY) = LatLonToTile(latitude, longitude, zoom);
 
@@ -287,7 +282,7 @@ public class CacheStatusService
 
                 var zoomDetails = new List<ZoomLevelCoverage>();
 
-                foreach (var zoom in FullCheckZoomLevels)
+                foreach (var zoom in TileCacheConstants.AllZoomLevels)
                 {
                     var (centerX, centerY) = LatLonToTile(latitude, longitude, zoom);
                     int zoomTotal = 0;

--- a/src/WayfarerMobile/Services/TileCache/LiveTileCacheService.cs
+++ b/src/WayfarerMobile/Services/TileCache/LiveTileCacheService.cs
@@ -131,10 +131,8 @@ public class LiveTileCacheService
         int radius = _settingsService.LiveCachePrefetchRadius;
         int maxConcurrent = _settingsService.MaxConcurrentTileDownloads;
 
-        // Zoom levels ordered by importance:
-        // 1. Current view (15), one up (14), one down (16) - most crucial
-        // 2. Rest for full coverage: 13, 12, 11, 10, 17
-        int[] zoomLevels = { 15, 14, 16, 13, 12, 11, 10, 17 };
+        // Use centralized zoom levels (8-17) ordered by importance
+        int[] zoomLevels = TileCacheConstants.AllZoomLevels;
 
         // Collect all tile coordinates to download
         var tilesToFetch = new List<(int zoom, int x, int y)>();

--- a/src/WayfarerMobile/Services/TileCache/TileCacheConstants.cs
+++ b/src/WayfarerMobile/Services/TileCache/TileCacheConstants.cs
@@ -1,0 +1,46 @@
+namespace WayfarerMobile.Services.TileCache;
+
+/// <summary>
+/// Centralized constants for tile cache configuration.
+/// All tile-related services should use these constants for consistency.
+/// </summary>
+public static class TileCacheConstants
+{
+    /// <summary>
+    /// Minimum zoom level for tile caching (zoomed out, region view).
+    /// </summary>
+    public const int MinZoomLevel = 8;
+
+    /// <summary>
+    /// Maximum zoom level for tile caching (zoomed in, street detail).
+    /// </summary>
+    public const int MaxZoomLevel = 17;
+
+    /// <summary>
+    /// All zoom levels for full tile operations (prefetch, full status check, trip download).
+    /// Ordered by priority: most commonly used navigation zoom levels first.
+    /// Range: 8-17 (10 zoom levels total).
+    /// </summary>
+    public static readonly int[] AllZoomLevels = { 15, 14, 16, 13, 12, 11, 10, 9, 8, 17 };
+
+    /// <summary>
+    /// Quick check zoom levels for fast cache status verification.
+    /// Only checks the most commonly viewed zoom levels.
+    /// </summary>
+    public static readonly int[] QuickCheckZoomLevels = { 15, 14, 16 };
+
+    /// <summary>
+    /// Estimated tile size in bytes for download calculations.
+    /// Uses a conservative estimate weighted toward dense urban areas:
+    /// - Dense urban: 50-80 KB
+    /// - Suburban: 20-35 KB
+    /// - Rural: 5-15 KB
+    /// Value of 40 KB provides realistic worst-case estimates for storage planning.
+    /// </summary>
+    public const long EstimatedTileSizeBytes = 40000; // ~40KB (conservative, weighted toward urban)
+
+    /// <summary>
+    /// Default tile request timeout in milliseconds.
+    /// </summary>
+    public const int TileTimeoutMs = 10000;
+}

--- a/src/WayfarerMobile/Services/TripDownloadService.cs
+++ b/src/WayfarerMobile/Services/TripDownloadService.cs
@@ -3,6 +3,7 @@ using WayfarerMobile.Core.Interfaces;
 using WayfarerMobile.Core.Models;
 using WayfarerMobile.Data.Entities;
 using WayfarerMobile.Data.Services;
+using WayfarerMobile.Services.TileCache;
 
 namespace WayfarerMobile.Services;
 
@@ -16,10 +17,10 @@ public class TripDownloadService
     private readonly ISettingsService _settingsService;
     private readonly ILogger<TripDownloadService> _logger;
 
-    // Tile download configuration
-    private static readonly int[] DownloadZoomLevels = { 10, 11, 12, 13, 14, 15, 16 };
-    private const int TileTimeoutMs = 10000;
-    private const long EstimatedTileSizeBytes = 15000; // ~15KB average
+    // Tile download configuration - use centralized constants for consistency
+    private static int[] DownloadZoomLevels => TileCacheConstants.AllZoomLevels;
+    private const int TileTimeoutMs = TileCacheConstants.TileTimeoutMs;
+    private const long EstimatedTileSizeBytes = TileCacheConstants.EstimatedTileSizeBytes;
     private const long MinRequiredSpaceMB = 50; // Minimum free space required
 
     // Rate limiting state
@@ -745,8 +746,8 @@ public class TripDownloadService
         var areaSquareDegrees = (bbox.North - bbox.South) * (bbox.East - bbox.West);
         var recommendedMaxZoom = GetRecommendedMaxZoom(areaSquareDegrees);
 
-        const int minZoom = 10;
-        var effectiveMaxZoom = Math.Min(recommendedMaxZoom, DownloadZoomLevels.Max());
+        int minZoom = TileCacheConstants.MinZoomLevel;
+        var effectiveMaxZoom = Math.Min(recommendedMaxZoom, TileCacheConstants.MaxZoomLevel);
 
         _logger.LogInformation("Area: {Area:F2} sq degrees, using zoom levels {Min}-{Max}",
             areaSquareDegrees, minZoom, effectiveMaxZoom);


### PR DESCRIPTION
## Summary
Centralized zoom level configuration across all tile-related services and extended the range from 10-17 to 8-17 for better zoomed-out coverage.

## Changes

### New File: `TileCacheConstants.cs`
- `MinZoomLevel` / `MaxZoomLevel` (8-17)
- `AllZoomLevels` (priority ordered for prefetch)
- `QuickCheckZoomLevels` (fast status checks)
- `EstimatedTileSizeBytes` (40KB - conservative urban estimate)
- `TileTimeoutMs`

### Updated Services
| Service | Change |
|---------|--------|
| `LiveTileCacheService` | Uses `AllZoomLevels` for prefetch |
| `CacheStatusService` | Uses constants for quick/full checks |
| `CacheOverlayService` | Uses `AllZoomLevels`, added zoom 8-9 radii |
| `TripDownloadService` | Uses constants for min/max zoom and tile size |

## Benefits
- Single source of truth for zoom configuration
- Consistent zoom levels (8-17) across all tile features
- Extended coverage for better zoomed-out views
- More accurate storage estimates with 40KB tiles (urban areas)

## Test plan
- [ ] Verify live cache prefetch works at zoom 8-17
- [ ] Verify trip download uses zoom 8-17
- [ ] Verify cache overlay displays all zoom levels
- [ ] Verify status checks work correctly