### PR TITLE
feat: add trip info panel to trips page

### DIFF
--- a/src/WayfarerMobile/ViewModels/TripsViewModel.cs
+++ b/src/WayfarerMobile/ViewModels/TripsViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Text.RegularExpressions;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WayfarerMobile.Core.Enums;
@@ -51,6 +52,12 @@ public partial class TripsViewModel : BaseViewModel
     [NotifyPropertyChangedFor(nameof(HasPlaces))]
     [NotifyPropertyChangedFor(nameof(HasSegments))]
     [NotifyPropertyChangedFor(nameof(SegmentDisplayItems))]
+    [NotifyPropertyChangedFor(nameof(PlacesCount))]
+    [NotifyPropertyChangedFor(nameof(SegmentsCount))]
+    [NotifyPropertyChangedFor(nameof(RegionsCount))]
+    [NotifyPropertyChangedFor(nameof(HasTripNotes))]
+    [NotifyPropertyChangedFor(nameof(TripNotesPreview))]
+    [NotifyPropertyChangedFor(nameof(TripNotesPlainText))]
     private TripDetails? _selectedTripDetails;
 
     /// <summary>
@@ -151,6 +158,18 @@ public partial class TripsViewModel : BaseViewModel
     [ObservableProperty]
     private bool _isSelectedTripDownloaded;
 
+    /// <summary>
+    /// Gets or sets whether the trip info panel is expanded.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isTripInfoExpanded = true;
+
+    /// <summary>
+    /// Gets or sets whether the trip notes section is expanded.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isTripNotesExpanded;
+
     #endregion
 
     #region Computed Properties
@@ -174,6 +193,36 @@ public partial class TripsViewModel : BaseViewModel
     /// Gets whether the selected trip has segments.
     /// </summary>
     public bool HasSegments => SelectedTripDetails?.Segments.Any() ?? false;
+
+    /// <summary>
+    /// Gets the count of places in the selected trip.
+    /// </summary>
+    public int PlacesCount => SelectedTripDetails?.AllPlaces?.Count ?? 0;
+
+    /// <summary>
+    /// Gets the count of segments in the selected trip.
+    /// </summary>
+    public int SegmentsCount => SelectedTripDetails?.Segments?.Count ?? 0;
+
+    /// <summary>
+    /// Gets the count of regions in the selected trip.
+    /// </summary>
+    public int RegionsCount => SelectedTripDetails?.Regions?.Count ?? 0;
+
+    /// <summary>
+    /// Gets whether the selected trip has notes.
+    /// </summary>
+    public bool HasTripNotes => !string.IsNullOrWhiteSpace(SelectedTripDetails?.Notes);
+
+    /// <summary>
+    /// Gets a preview of the trip notes (first 100 characters).
+    /// </summary>
+    public string TripNotesPreview => GetNotesPreview();
+
+    /// <summary>
+    /// Gets the trip notes with HTML stripped.
+    /// </summary>
+    public string TripNotesPlainText => StripHtml(SelectedTripDetails?.Notes ?? string.Empty);
 
     /// <summary>
     /// Gets the segment display items for the sidebar, using cached value when available.
@@ -405,6 +454,24 @@ public partial class TripsViewModel : BaseViewModel
     private void CloseSidebar()
     {
         IsSidebarOpen = false;
+    }
+
+    /// <summary>
+    /// Toggles the trip info panel expansion state.
+    /// </summary>
+    [RelayCommand]
+    private void ToggleTripInfo()
+    {
+        IsTripInfoExpanded = !IsTripInfoExpanded;
+    }
+
+    /// <summary>
+    /// Toggles the trip notes section expansion state.
+    /// </summary>
+    [RelayCommand]
+    private void ToggleTripNotes()
+    {
+        IsTripNotesExpanded = !IsTripNotesExpanded;
     }
 
     /// <summary>
@@ -880,6 +947,26 @@ public partial class TripsViewModel : BaseViewModel
     #endregion
 
     #region Private Helpers
+
+    /// <summary>
+    /// Gets a preview of the trip notes (first 100 characters).
+    /// </summary>
+    private string GetNotesPreview()
+    {
+        var plainText = StripHtml(SelectedTripDetails?.Notes ?? string.Empty);
+        return plainText.Length > 100 ? plainText[..100] + "..." : plainText;
+    }
+
+    /// <summary>
+    /// Strips HTML tags from a string.
+    /// </summary>
+    /// <param name="html">The HTML string to process.</param>
+    /// <returns>Plain text with HTML removed.</returns>
+    private static string StripHtml(string html)
+    {
+        if (string.IsNullOrEmpty(html)) return string.Empty;
+        return Regex.Replace(html, "<[^>]*>", "").Trim();
+    }
 
     /// <summary>
     /// Builds the segment display items from the current trip details.

--- a/src/WayfarerMobile/Views/TripsPage.xaml
+++ b/src/WayfarerMobile/Views/TripsPage.xaml
@@ -282,7 +282,7 @@
 
                 <!-- Main Content View -->
                 <navDrawer:SfNavigationDrawer.ContentView>
-                    <Grid RowDefinitions="Auto,Auto,*">
+                    <Grid RowDefinitions="Auto,Auto,Auto,*">
                         <!-- Header with Back Button and Actions -->
                         <Grid Grid.Row="0"
                               ColumnDefinitions="Auto,*,Auto,Auto"
@@ -359,8 +359,60 @@
                             </Grid>
                         </Grid>
 
+                        <!-- Trip Info Panel -->
+                        <Border Grid.Row="2"
+                                IsVisible="{Binding ShowingDetails}"
+                                BackgroundColor="{StaticResource Surface}"
+                                Padding="12,8">
+                            <VerticalStackLayout Spacing="8">
+                                <!-- Stats row - tap to toggle expansion -->
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <Grid.GestureRecognizers>
+                                        <TapGestureRecognizer Command="{Binding ToggleTripInfoCommand}" />
+                                    </Grid.GestureRecognizers>
+                                    <HorizontalStackLayout Spacing="12">
+                                        <Label Text="{Binding PlacesCount, StringFormat='{0} places'}"
+                                               Style="{StaticResource Caption}" />
+                                        <Label Text="{Binding SegmentsCount, StringFormat='{0} segments'}"
+                                               Style="{StaticResource Caption}"
+                                               IsVisible="{Binding HasSegments}" />
+                                        <Label Text="{Binding RegionsCount, StringFormat='{0} regions'}"
+                                               Style="{StaticResource Caption}" />
+                                    </HorizontalStackLayout>
+                                    <Label Grid.Column="1"
+                                           Text="v"
+                                           FontSize="12"
+                                           TextColor="{StaticResource TextSecondary}"
+                                           IsVisible="{Binding IsTripInfoExpanded, Converter={StaticResource InvertedBoolConverter}}" />
+                                    <Label Grid.Column="1"
+                                           Text="^"
+                                           FontSize="12"
+                                           TextColor="{StaticResource TextSecondary}"
+                                           IsVisible="{Binding IsTripInfoExpanded}" />
+                                </Grid>
+
+                                <!-- Expanded content -->
+                                <VerticalStackLayout IsVisible="{Binding IsTripInfoExpanded}" Spacing="8">
+                                    <!-- Notes section -->
+                                    <VerticalStackLayout IsVisible="{Binding HasTripNotes}" Spacing="4">
+                                        <Label Text="Notes"
+                                               Style="{StaticResource Caption}"
+                                               FontAttributes="Bold" />
+                                        <Label Text="{Binding TripNotesPlainText}"
+                                               Style="{StaticResource Body}"
+                                               MaxLines="5"
+                                               LineBreakMode="TailTruncation" />
+                                    </VerticalStackLayout>
+                                    <!-- Last updated -->
+                                    <Label Text="{Binding SelectedTripDetails.UpdatedAt, StringFormat='Updated: {0:MMM d, yyyy}'}"
+                                           Style="{StaticResource Caption}"
+                                           TextColor="{StaticResource Gray400}" />
+                                </VerticalStackLayout>
+                            </VerticalStackLayout>
+                        </Border>
+
                         <!-- Full Map View -->
-                        <Grid Grid.Row="2">
+                        <Grid Grid.Row="3">
                             <mapsui:MapControl Map="{Binding Map}" />
 
                             <!-- Loading overlay -->


### PR DESCRIPTION
## Summary
Added a collapsible trip info panel that displays trip statistics and notes when viewing a trip on the map.

## Features
- **Stats row**: Shows places count, segments count (if any), and regions count
- **Expandable panel**: Tap to toggle expansion
- **Trip notes**: Displays notes with HTML stripped (if available)
- **Last updated**: Shows when the trip was last modified

## Changes

### TripsViewModel.cs
- Added `IsTripInfoExpanded`, `IsTripNotesExpanded` observable properties
- Added computed properties:
  - `PlacesCount`, `SegmentsCount`, `RegionsCount`
  - `HasTripNotes`, `TripNotesPreview`, `TripNotesPlainText`
- Added commands: `ToggleTripInfoCommand`, `ToggleTripNotesCommand`
- Added `StripHtml()` helper method for notes display

### TripsPage.xaml
- Changed grid from 3 rows to 4 rows
- Added trip info panel in row 2 (between header and map)
- Uses existing styles for consistency

## Test plan
- [ ] Verify trip info panel shows when viewing a trip
- [ ] Verify places/segments/regions counts are correct
- [ ] Verify expand/collapse works
- [ ] Verify notes display correctly (HTML stripped)
- [ ] Verify last updated date shows

Fixes #4