### PR TITLE
docs: add CI and coverage badges to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,31 @@ jobs:
         recreate: true
         path: code-coverage-results.md
 
+    - name: Extract coverage percentage
+      id: coverage
+      if: always()
+      run: |
+        # Extract line coverage from cobertura XML
+        COVERAGE=$(grep -oP 'line-rate="\K[^"]+' tests/WayfarerMobile.Tests/coverage/coverage.cobertura.xml | head -1)
+        COVERAGE_PCT=$(echo "scale=0; $COVERAGE * 100 / 1" | bc)
+        echo "percentage=$COVERAGE_PCT" >> $GITHUB_OUTPUT
+        echo "Coverage: $COVERAGE_PCT%"
+
+    - name: Update coverage badge
+      uses: schneegans/dynamic-badges-action@v1.7.0
+      if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+      continue-on-error: true
+      with:
+        auth: ${{ secrets.GIST_TOKEN }}
+        gistID: ${{ vars.COVERAGE_GIST_ID }}
+        filename: coverage.json
+        label: Code Coverage
+        message: ${{ steps.coverage.outputs.percentage }}%
+        valColorRange: ${{ steps.coverage.outputs.percentage }}
+        minColorRange: 50
+        maxColorRange: 90
+        namedLogo: dotnet
+
   build-maui:
     name: Build MAUI App
     runs-on: windows-latest

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/stef-k/WayfarerMobile/actions/workflows/ci.yml"><img src="https://github.com/stef-k/WayfarerMobile/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/stef-k/9361b6aaa8c346069ce1e1c0581b41b1/raw/coverage.json" alt="Code Coverage">
   <img src="https://img.shields.io/badge/.NET-10.0-512BD4?style=flat-square&logo=dotnet" alt=".NET 10">
   <img src="https://img.shields.io/badge/MAUI-Cross--Platform-512BD4?style=flat-square" alt="MAUI">
   <img src="https://img.shields.io/badge/Platform-Android%20%7C%20iOS-green?style=flat-square" alt="Platforms">


### PR DESCRIPTION
## Summary
Adds CI status and dynamic code coverage badges to README.

## Changes
- Add CI badge linking to GitHub Actions workflow
- Add dynamic coverage badge that reads from gist
- Add CI step to extract coverage and update gist

## Setup Required
For the coverage badge to work:
1. Add secret `GIST_TOKEN` (PAT with gist scope)
2. Add variable `COVERAGE_GIST_ID` = `9361b6aaa8c346069ce1e1c0581b41b1`

## Test plan
- [ ] Merge PR and verify badges appear on main README
- [ ] Verify CI badge shows passing/failing status
- [ ] After gist setup, verify coverage badge updates