### PR TITLE
fix: unload trip from map when deleted from My Trips

### DIFF
--- a/src/WayfarerMobile/MainPage.xaml.cs
+++ b/src/WayfarerMobile/MainPage.xaml.cs
@@ -234,6 +234,12 @@ public partial class MainPage : ContentPage, IQueryAttributable
         {
             _pendingTrip = trip;
         }
+
+        // Handle UnloadTrip signal (when trip is deleted from TripsPage)
+        if (query.TryGetValue("UnloadTrip", out var unloadObj) && unloadObj is bool unload && unload)
+        {
+            _viewModel.UnloadTrip();
+        }
     }
 
     /// <summary>

--- a/src/WayfarerMobile/Services/TripNavigationService.cs
+++ b/src/WayfarerMobile/Services/TripNavigationService.cs
@@ -51,6 +51,11 @@ public class TripNavigationService
     /// </summary>
     public bool IsTripLoaded => _currentGraph != null;
 
+    /// <summary>
+    /// Gets the ID of the currently loaded trip, or null if no trip is loaded.
+    /// </summary>
+    public Guid? CurrentTripId => _currentTrip?.Id;
+
     // Turn announcement tracking
     private string? _lastAnnouncedWaypoint;
     private DateTime _lastAnnouncementTime = DateTime.MinValue;


### PR DESCRIPTION
When a user deletes a downloaded trip from the My Trips tab, the app now checks if that trip is currently loaded on the map and automatically unloads it to prevent showing stale trip data.

## Changes
- TripNavigationService: Added CurrentTripId property to expose loaded trip ID
- TripsViewModel: Check if deleted trip is loaded and unload via navigation service
- MainPage: Handle UnloadTrip query parameter to call MainViewModel.UnloadTrip()

## Test Plan
- [ ] Delete a trip that is NOT loaded on the map - should work as before
- [ ] Delete a trip that IS currently loaded on the map - should unload trip layers