### PR TITLE
fix: include region cover image and notes in SortedRegions property

### DIFF
--- a/src/WayfarerMobile.Core/Models/TripModels.cs
+++ b/src/WayfarerMobile.Core/Models/TripModels.cs
@@ -243,6 +243,10 @@ public class TripDetails
             {
                 Id = r.Id,
                 Name = r.Name,
+                Notes = r.Notes,
+                CoverImageUrl = r.CoverImageUrl,
+                CenterLatitude = r.CenterLatitude,
+                CenterLongitude = r.CenterLongitude,
                 SortOrder = r.SortOrder,
                 Places = r.Places.OrderBy(p => p.SortOrder).ToList(),
                 Areas = r.Areas.OrderBy(a => a.SortOrder).ToList()


### PR DESCRIPTION
The SortedRegions property was creating new TripRegion instances but was not copying the CoverImageUrl and Notes properties. This caused conditional visibility bindings to always evaluate to false.

## Changes
Added missing property mappings in SortedRegions:
- Notes
- CoverImageUrl
- CenterLatitude
- CenterLongitude

## Test Plan
- [ ] Verify region cover images appear when present
- [ ] Verify region notes appear when present
- [ ] Verify regions without cover/notes don't show empty sections