### PR TITLE
fix: hide location text when no location info is available

### DIFF
--- a/src/WayfarerMobile/App.xaml
+++ b/src/WayfarerMobile/App.xaml
@@ -30,6 +30,7 @@
             <converters:IndexToColorConverter x:Key="IndexToColorConverter" />
             <converters:HtmlToTextConverter x:Key="HtmlToTextConverter" />
             <converters:MauiAssetImageConverter x:Key="MauiAssetImageConverter" />
+            <converters:HasLocationInfoConverter x:Key="HasLocationInfoConverter" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/WayfarerMobile/Converters/NullConverters.cs
+++ b/src/WayfarerMobile/Converters/NullConverters.cs
@@ -128,3 +128,31 @@ public class PercentToDecimalConverter : IValueConverter
         throw new NotImplementedException();
     }
 }
+
+/// <summary>
+/// Converts a string to false if it matches "No location info", otherwise true.
+/// Used to hide fallback text that provides no useful information.
+/// </summary>
+public class HasLocationInfoConverter : IValueConverter
+{
+    /// <summary>
+    /// Converts a string to false if it matches "No location info".
+    /// </summary>
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is string text)
+        {
+            return !string.Equals(text, "No location info", StringComparison.Ordinal);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Not implemented.
+    /// </summary>
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/WayfarerMobile/Views/Controls/MyTripsView.xaml
+++ b/src/WayfarerMobile/Views/Controls/MyTripsView.xaml
@@ -81,9 +81,10 @@
                                            TextColor="White" />
                                 </Border>
 
-                                <!-- Location Info -->
+                                <!-- Location Info (hidden when no location data) -->
                                 <Label Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
                                        Text="{Binding LocationsText}"
+                                       IsVisible="{Binding LocationsText, Converter={StaticResource HasLocationInfoConverter}}"
                                        FontSize="13"
                                        TextColor="{AppThemeBinding Light={StaticResource TextSecondary}, Dark={StaticResource TextSecondaryDark}}"
                                        LineBreakMode="TailTruncation" />


### PR DESCRIPTION
The MyTripsView was showing 'No location info' for trips without cities or countries defined. This fallback text provided no useful information.

## Changes
- Added HasLocationInfoConverter to filter out 'No location info' fallback
- Registered converter in App.xaml resources
- Updated MyTripsView.xaml to conditionally hide location label

## Result
The location row is now hidden when there's no actual location data, resulting in a cleaner UI.

## Test Plan
- [ ] Verify trips with cities/countries show location info
- [ ] Verify trips without cities/countries hide the location row entirely