### PR TITLE
fix: use zoom level 2 for full globe view on cold start

### DIFF
--- a/src/WayfarerMobile/ViewModels/MainViewModel.cs
+++ b/src/WayfarerMobile/ViewModels/MainViewModel.cs
@@ -1014,11 +1014,11 @@ public partial class MainViewModel : BaseViewModel
         }
         else
         {
-            // No location available - show globe view (zoom 3) so user sees something useful
+            // No location available - show globe view (zoom 2) so user sees the full globe
             // instead of being zoomed into the ocean at 0,0
-            if (map.Navigator.Resolutions?.Count > 3)
+            if (map.Navigator.Resolutions?.Count > 2)
             {
-                map.Navigator.ZoomTo(map.Navigator.Resolutions[3]);
+                map.Navigator.ZoomTo(map.Navigator.Resolutions[2]);
             }
             _logger.LogDebug("Map initialized at globe view (no location available)");
         }


### PR DESCRIPTION
## Summary

Fixes #12 - On cold start with no cached location, zoom level 3 showed only a partial view. Changed to zoom level 2 for a full globe view.

## Changes

- `MainViewModel.cs`: Changed `Resolutions[3]` to `Resolutions[2]`

## Before/After

| Before (Zoom 3) | After (Zoom 2) |
|-----------------|----------------|
| Partial region visible | Full globe visible |

## Test Plan

- [ ] Fresh install (no cached location) → should see full globe
- [ ] Force stop with cached location → should still center on last known location