### PR TITLE
fix: prevent crash on startup after clearing app data (#40)

### DIFF
--- a/src/WayfarerMobile.Core/Interfaces/ISettingsService.cs
+++ b/src/WayfarerMobile.Core/Interfaces/ISettingsService.cs
@@ -214,4 +214,10 @@ public interface ISettingsService
     /// Clears authentication data only (server URL and token).
     /// </summary>
     void ClearAuth();
+
+    /// <summary>
+    /// Resets all settings to defaults. Used for recovery when app state is corrupted
+    /// (e.g., after user clears app data from Android Settings).
+    /// </summary>
+    void ResetToDefaults();
 }

--- a/src/WayfarerMobile/Platforms/Android/MainActivity.cs
+++ b/src/WayfarerMobile/Platforms/Android/MainActivity.cs
@@ -1,4 +1,5 @@
 ﻿using Android.App;
+using Android.Content;
 using Android.Content.PM;
 using Android.OS;
 
@@ -7,4 +8,101 @@ namespace WayfarerMobile;
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
+    /// <summary>
+    /// Static flag that persists for the lifetime of the process.
+    /// Set to true after first successful initialization.
+    /// If this is true but preferences are cleared, we know data was cleared externally.
+    /// </summary>
+    private static bool s_processInitialized;
+
+    /// <summary>
+    /// Key used to mark that we've written to preferences in this process.
+    /// </summary>
+    private const string ProcessMarkerKey = "process_marker";
+
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        // Early check for corrupted state before MAUI initializes.
+        // This handles the case where app data was cleared while the process was alive.
+        if (DetectAndRecoverFromCorruptedState())
+        {
+            // State was corrupted - we've cleared it, now restart the app process
+            System.Diagnostics.Debug.WriteLine("[MainActivity] Corrupted state detected - restarting app");
+            RestartApp();
+            return;
+        }
+
+        base.OnCreate(savedInstanceState);
+    }
+
+    /// <summary>
+    /// Detects if app data was cleared while the process was running.
+    /// Uses a static flag + preferences marker to detect the mismatch.
+    /// </summary>
+    private bool DetectAndRecoverFromCorruptedState()
+    {
+        try
+        {
+            // MAUI Preferences uses a specific SharedPreferences file
+            var prefs = GetSharedPreferences($"{PackageName}.microsoft.maui.essentials.preferences", FileCreationMode.Private);
+            if (prefs == null)
+                return false;
+
+            // Check if our process marker exists in preferences
+            var hasProcessMarker = prefs.Contains(ProcessMarkerKey);
+
+            // Case 1: Process was initialized before, but marker is gone → data was cleared
+            if (s_processInitialized && !hasProcessMarker)
+            {
+                System.Diagnostics.Debug.WriteLine("[MainActivity] Corruption detected: process initialized but marker missing");
+                return true; // Will trigger restart
+            }
+
+            // Case 2: First time in this process - set up the marker
+            if (!s_processInitialized)
+            {
+                s_processInitialized = true;
+
+                // Write marker to preferences
+                var editor = prefs.Edit();
+                editor?.PutBoolean(ProcessMarkerKey, true);
+                editor?.Apply();
+
+                System.Diagnostics.Debug.WriteLine("[MainActivity] Process marker set");
+            }
+
+            return false;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[MainActivity] Error checking state: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Restarts the app by killing the current process and launching a new one.
+    /// This ensures all singletons are cleared.
+    /// </summary>
+    private void RestartApp()
+    {
+        try
+        {
+            var packageManager = PackageManager;
+            var intent = packageManager?.GetLaunchIntentForPackage(PackageName ?? "");
+            if (intent != null)
+            {
+                intent.AddFlags(ActivityFlags.ClearTop | ActivityFlags.NewTask | ActivityFlags.ClearTask);
+                StartActivity(intent);
+            }
+
+            // Kill the current process to clear all singletons
+            Java.Lang.JavaSystem.Exit(0);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[MainActivity] Failed to restart app: {ex.Message}");
+            // Fall through to normal startup
+        }
+    }
 }

--- a/src/WayfarerMobile/ViewModels/OnboardingViewModel.cs
+++ b/src/WayfarerMobile/ViewModels/OnboardingViewModel.cs
@@ -35,6 +35,7 @@ public partial class OnboardingViewModel : BaseViewModel
     [NotifyPropertyChangedFor(nameof(ShowSkipButton))]
     [NotifyPropertyChangedFor(nameof(ShowRequestButton))]
     [NotifyPropertyChangedFor(nameof(StepProgress))]
+    [NotifyPropertyChangedFor(nameof(DisplayStep))]
     private int _currentStep;
 
     /// <summary>
@@ -102,6 +103,11 @@ public partial class OnboardingViewModel : BaseViewModel
     /// Gets the progress value (0.0 to 1.0).
     /// </summary>
     public double StepProgress => (double)(CurrentStep + 1) / TotalSteps;
+
+    /// <summary>
+    /// Gets the current step as 1-based for display (1 to 6).
+    /// </summary>
+    public int DisplayStep => CurrentStep + 1;
 
     /// <summary>
     /// Gets the current step title.

--- a/src/WayfarerMobile/Views/Onboarding/OnboardingPage.xaml
+++ b/src/WayfarerMobile/Views/Onboarding/OnboardingPage.xaml
@@ -13,11 +13,14 @@
         <!-- Progress indicator at top -->
         <VerticalStackLayout Grid.Row="0" Spacing="10" Margin="0,20,0,20">
             <sfProgress:SfLinearProgressBar Progress="{Binding StepProgress}"
-                                            ProgressHeight="6"
-                                            TrackHeight="6"
+                                            Minimum="0"
+                                            Maximum="1"
+                                            ProgressHeight="10"
+                                            TrackHeight="10"
+                                            CornerRadius="5"
                                             ProgressFill="{StaticResource Primary}"
                                             TrackFill="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray700}}" />
-            <Label Text="{Binding CurrentStep, StringFormat='Step {0:N0} of 6'}"
+            <Label Text="{Binding DisplayStep, StringFormat='Step {0} of 6'}"
                    FontSize="12"
                    HorizontalOptions="Center"
                    TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray400}}" />


### PR DESCRIPTION
## Summary
Fixes #40 - App crashes on startup after user clears app data via Android Settings.

When users clear app data from Android Settings, the app process may still be alive (due to foreground service), causing DI singletons to have stale state that crashes the app.

## Changes

### Corruption Detection (MainActivity)
- Added early corruption detection in `MainActivity.OnCreate` before MAUI initializes
- Uses static flag (`s_processInitialized`) + preferences marker to detect when data was cleared while process was running
- Forces app restart when corruption detected to clear all stale singletons

### SecureStorage Resilience (SettingsService)
- Added try-catch around `SecureStorage.GetAsync()` calls in `ServerUrl` and `ApiToken` getters
- Added try-catch in `PreloadSecureSettingsAsync()`
- Added `ResetToDefaults()` method to reset corrupted state to defaults

### AppShell Recovery Mode
- Added defensive try-catch around DI resolution in constructor
- Added `TryRecoverFromCorruptedState()` helper
- Recovery mode navigates to onboarding after resetting settings

### App Resume Check
- Added `CheckAndRecoverFromCorruptedStateAsync()` in `OnWindowResumed`
- Detects corruption when app resumes from background after data clear

### Bonus: Onboarding Progress Bar Fix
- Fixed progress bar not animating (set `Maximum="1"` for 0.0-1.0 range)
- Fixed step label showing 0-based index (added `DisplayStep` property)
- Made progress bar thicker (10px) with rounded corners

## Testing Notes
⚠️ **Debug builds with Fast Deployment**: Clearing app data will cause a different crash (missing assemblies) because Fast Deployment stores .NET assemblies in the app's data directory. This is expected for debug builds.

**To test the actual fix**, either:
1. Deploy a Release build
2. Disable Fast Deployment in project settings
3. Redeploy after clearing data

## Test Plan
- [ ] Deploy Release build, complete onboarding
- [ ] Clear app data from Android Settings (without force stop)
- [ ] Open app - should restart and show onboarding (not crash)
- [ ] Verify onboarding progress bar animates correctly (Step 1-6)