### PR TITLE
fix: remove invalid CornerRadius property from SfLinearProgressBar

### DIFF
--- a/src/WayfarerMobile/Views/Onboarding/OnboardingPage.xaml
+++ b/src/WayfarerMobile/Views/Onboarding/OnboardingPage.xaml
@@ -17,7 +17,6 @@
                                             Maximum="1"
                                             ProgressHeight="10"
                                             TrackHeight="10"
-                                            CornerRadius="5"
                                             ProgressFill="{StaticResource Primary}"
                                             TrackFill="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray700}}" />
             <Label Text="{Binding DisplayStep, StringFormat='Step {0} of 6'}"


### PR DESCRIPTION
## Summary

Fixes CI build failure caused by invalid `CornerRadius` property on Syncfusion `SfLinearProgressBar`.

## Error
```
OnboardingPage.xaml(20,45): XamlC error XC0009: No property, BindableProperty, or event found for "CornerRadius"
```

## Fix
Removed the unsupported `CornerRadius="5"` attribute from the progress bar. The control doesn't support this property.