### PR TITLE
feat: increase max queued locations to 25,000 (#49)

### DIFF
--- a/src/WayfarerMobile/Data/Services/DatabaseService.cs
+++ b/src/WayfarerMobile/Data/Services/DatabaseService.cs
@@ -14,7 +14,7 @@ public class DatabaseService : IAsyncDisposable
 
     private const string DatabaseFilename = "wayfarer.db3";
     private const int MaxSyncAttempts = 5;
-    private const int MaxQueuedLocations = 10000;
+    private const int MaxQueuedLocations = 25000;
 
     private static readonly SQLiteOpenFlags DbFlags =
         SQLiteOpenFlags.ReadWrite |


### PR DESCRIPTION
## Summary
Increase MaxQueuedLocations from 10,000 to 25,000 to extend offline use capability.

| Metric | Before | After |
|--------|--------|-------|
| Max queued locations | 10,000 | 25,000 |
| Offline duration (5min/15m thresholds) | ~1 month | >2 months |

## Changes
- `DatabaseService.cs`: Updated `MaxQueuedLocations` constant from 10,000 to 25,000

## Test plan
- [x] Build succeeds
- [x] All 1565 tests pass

Closes #49