### PR TITLE
fix: re-subscribe map tap events after navigation (#50)

### DIFF
--- a/src/WayfarerMobile/Views/TimelinePage.xaml.cs
+++ b/src/WayfarerMobile/Views/TimelinePage.xaml.cs
@@ -26,15 +26,11 @@ public partial class TimelinePage : ContentPage
         BindingContext = viewModel;
 
         Loaded += OnPageLoaded;
-
-        // Subscribe to coordinate picking mode changes to manage bottom sheet state
-        _viewModel.PropertyChanged += OnViewModelPropertyChanged;
     }
 
     private void OnPageLoaded(object? sender, EventArgs e)
     {
-        MapControl.Info += OnMapInfo;
-
+        // Initialize map only once when page is first loaded
         if (MapControl.Map == null)
         {
             MapControl.Map = _viewModel.Map;
@@ -169,6 +165,11 @@ public partial class TimelinePage : ContentPage
     protected override async void OnAppearing()
     {
         base.OnAppearing();
+
+        // Re-subscribe event handlers (unsubscribed in OnDisappearing)
+        MapControl.Info += OnMapInfo;
+        _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+
         await _viewModel.OnAppearingAsync();
     }
 


### PR DESCRIPTION
## Summary
- Fixed bottom sheet not responding to marker taps after navigating to notes editor and back
- Moved event subscriptions (`MapControl.Info` and `PropertyChanged`) from constructor/OnPageLoaded to `OnAppearing`
- Events are now properly re-subscribed each time the page appears, matching the pattern used in GroupsPage

## Root Cause
Events were subscribed once (in constructor/OnPageLoaded) but unsubscribed in `OnDisappearing`. When returning from the notes editor, events were never re-subscribed.

## Test plan
- [x] Open Timeline page
- [x] Tap a location marker - bottom sheet should open
- [x] Edit → Edit Notes → navigate to notes editor
- [x] Save/cancel and return to Timeline
- [x] Tap a location marker again - bottom sheet should open (was broken before fix)

Fixes #50