### PR TITLE
fix: sync wake timing with ThresholdFilter for deterministic GPS accuracy

### DIFF
--- a/src/WayfarerMobile.Core/Algorithms/ThresholdFilter.cs
+++ b/src/WayfarerMobile.Core/Algorithms/ThresholdFilter.cs
@@ -118,4 +118,27 @@ public class ThresholdFilter
         TimeThresholdMinutes = timeMinutes;
         DistanceThresholdMeters = distanceMeters;
     }
+
+    /// <summary>
+    /// Gets the number of seconds until the next time-based log is due.
+    /// Returns 0 or negative if a log is already due.
+    /// Returns null if no location has been logged yet.
+    /// </summary>
+    /// <remarks>
+    /// This is the single source of truth for wake/sleep timing in the location service.
+    /// The service should wake up (buffer) seconds before this value reaches 0.
+    /// </remarks>
+    public double? GetSecondsUntilNextLog()
+    {
+        lock (_lock)
+        {
+            if (_lastLoggedLocation == null)
+                return null;
+
+            var secondsSinceLastLog = (DateTime.UtcNow - _lastLoggedLocation.Timestamp).TotalSeconds;
+            var thresholdSeconds = TimeThresholdMinutes * 60.0;
+
+            return thresholdSeconds - secondsSinceLastLog;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- ThresholdFilter now serves as single source of truth for wake/sleep timing
- Eliminates timing drift that caused 100m locations to be logged instead of high-accuracy GPS fixes
- Three-phase approach ensures deterministic wake timing

## Changes
| File | Change |
|------|--------|
| `ThresholdFilter.cs` | Added `GetSecondsUntilNextLog()` method |
| `LocationTrackingService.cs` | Queries ThresholdFilter for wake decisions, implements three-phase sleep/wake |

## How It Works

### Three-Phase Timing (for 5-min threshold)
1. **Deep Sleep** (~135s): Balanced mode, long interval
2. **Approach Phase** (60-120s before threshold): 30s polling to catch wake window
3. **Wake Phase** (≤60s before threshold): HighAccuracy mode, best location tracking

### Bad GPS Handling
- 120s timeout during wake phase
- Tracks best location received during wake
- Falls back to best available if no good fix

## Test Results
| Cycle | Logged Accuracy | Previous Behavior |
|-------|-----------------|-------------------|
| 1 | 14m ✓ | 100m |
| 2 | 13m ✓ | 100m |

## Test plan
- [x] Verify wake triggers ~60s before threshold
- [x] Verify GPS fix acquired during wake phase
- [x] Verify logged accuracy is <50m (not 100m)
- [x] Verify consistent behavior across multiple cycles