### PR TITLE
fix: visit notification toggle and Android silent channel

### DIFF
--- a/src/WayfarerMobile/ViewModels/SettingsViewModel.cs
+++ b/src/WayfarerMobile/ViewModels/SettingsViewModel.cs
@@ -37,6 +37,7 @@ public partial class SettingsViewModel : BaseViewModel
     private readonly TimelineImportService _importService;
     private readonly TimelineDataService _timelineDataService;
     private readonly IToastService _toastService;
+    private readonly IVisitNotificationService _visitNotificationService;
 
     #endregion
 
@@ -335,7 +336,8 @@ public partial class SettingsViewModel : BaseViewModel
         TimelineExportService exportService,
         TimelineImportService importService,
         TimelineDataService timelineDataService,
-        IToastService toastService)
+        IToastService toastService,
+        IVisitNotificationService visitNotificationService)
     {
         _settingsService = settingsService;
         _appLockService = appLockService;
@@ -344,6 +346,7 @@ public partial class SettingsViewModel : BaseViewModel
         _importService = importService;
         _timelineDataService = timelineDataService;
         _toastService = toastService;
+        _visitNotificationService = visitNotificationService;
         PinSecurity = new PinSecurityViewModel(appLockService);
         Title = "Settings";
         LoadSettings();
@@ -541,12 +544,22 @@ public partial class SettingsViewModel : BaseViewModel
     }
 
     /// <summary>
-    /// Saves visit notifications enabled setting and updates ShowVisitVoiceOption.
+    /// Saves visit notifications enabled setting, updates UI, and starts/stops the service.
     /// </summary>
     partial void OnVisitNotificationsEnabledChanged(bool value)
     {
         _settingsService.VisitNotificationsEnabled = value;
         OnPropertyChanged(nameof(ShowVisitVoiceOption));
+
+        // Start or stop the visit notification service immediately
+        if (value)
+        {
+            _ = _visitNotificationService.StartAsync();
+        }
+        else
+        {
+            _visitNotificationService.Stop();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Addresses review feedback from PR #62.

## Changes

### 1. Toggle now starts/stops service immediately
- `SettingsViewModel.OnVisitNotificationsEnabledChanged` now calls `StartAsync()`/`Stop()` on the service
- Setting takes effect immediately without app restart
- Toggling OFF stops the SSE subscription (was leaving it running)

### 2. Separate Android channel for silent notifications
On Android 8+, notification channel importance controls sound/vibration behavior, not per-notification settings.

| Channel | Importance | Sound | Vibration | Use Case |
|---------|------------|-------|-----------|----------|
| `wayfarer_visit_notifications` | Default | ✓ | ✓ | Normal visit alerts |
| `wayfarer_visit_silent` | Low | ✗ | ✗ | During navigation |

## Test plan
- [x] Build succeeds
- [x] All 1616 tests pass
- [ ] Manual: Toggle OFF stops notifications immediately
- [ ] Manual: Toggle ON starts notifications without restart
- [ ] Manual: Silent notifications don't vibrate/sound on Android