### PR TITLE
refactor: increase GPS wake buffer to 100s for cold start reliability

### DIFF
--- a/docs/docsify/05-Location-Tracking.md
+++ b/docs/docsify/05-Location-Tracking.md
@@ -177,37 +177,37 @@ Normal mode uses a **three-phase sleep/wake optimization** to save battery while
 │                    5-Minute Threshold Example                     │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                   │
-│  0:00       1:30       2:30       3:30       4:30    5:00        │
+│  0:00       1:20       2:00       3:20       4:20    5:00        │
 │    │         │          │          │          │        │          │
 │    ▼         ▼          ▼          ▼          ▼        ▼          │
 │  LOG ════════╪══════════╪══════════╪══════════╪════════╪ LOG     │
 │    │         │          │          │          │        │          │
 │    │◄───────►│◄────────►│◄────────►│◄────────►│        │          │
 │    │  Deep   │  Deep    │ Approach │   Wake   │(early  │          │
-│    │  Sleep  │  Sleep   │  (90s)   │  (90s)   │ stop)  │          │
+│    │  Sleep  │  Sleep   │  (100s)  │  (100s)  │ stop)  │          │
 │    │ Balanced│ Balanced │ Balanced │HighAccur │Balanced│          │
 │    │  ~100m  │  ~100m   │  ~100m   │  ≤20m    │ stored │          │
 │                                                                   │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-#### Phase 1: Deep Sleep (>180s before threshold)
+#### Phase 1: Deep Sleep (>200s before threshold)
 - **Priority**: Balanced (cell/WiFi positioning)
-- **Interval**: Long (~120s for 5-min threshold)
+- **Interval**: Long (~100s for 5-min threshold)
 - **Accuracy**: ~100m (acceptable, not logged)
 - **Battery**: Minimal usage
 
-#### Phase 2: Approach (90-180s before threshold)
+#### Phase 2: Approach (100-200s before threshold)
 - **Priority**: Balanced
 - **Interval**: 1 second (prepare for wake)
 - **Purpose**: Shorter polling to catch the wake window reliably
 - **Battery**: Low usage
 
-#### Phase 3: Wake (≤90s before threshold)
+#### Phase 3: Wake (≤100s before threshold)
 - **Priority**: HighAccuracy (GPS)
 - **Interval**: 1 second (collect many samples)
 - **Accuracy**: Target ≤20m (excellent GPS)
-- **Purpose**: Acquire high-accuracy fix for logging
+- **Purpose**: Acquire high-accuracy fix for logging (100s allows for cold start GPS)
 - **Best location tracking**: Keeps the best GPS fix seen during wake
 
 #### Early GPS Shutoff

--- a/docs/docsify/12-Services.md
+++ b/docs/docsify/12-Services.md
@@ -145,9 +145,9 @@ The service uses ThresholdFilter as the **single source of truth** for timing:
 
 | Phase | Seconds Until Log | Priority | Interval |
 |-------|-------------------|----------|----------|
-| Deep Sleep | >180s | Balanced | threshold - 180s |
-| Approach | 90-180s | Balanced | 1s |
-| Wake | ≤90s | HighAccuracy | 1s |
+| Deep Sleep | >200s | Balanced | threshold - 200s |
+| Approach | 100-200s | Balanced | 1s |
+| Wake | ≤100s | HighAccuracy | 1s |
 
 **Two-Tier Accuracy Thresholds**:
 - **Excellent (≤20m)**: Early GPS shutoff, stored sample used at threshold time

--- a/src/WayfarerMobile/Platforms/Android/Services/LocationTrackingService.cs
+++ b/src/WayfarerMobile/Platforms/Android/Services/LocationTrackingService.cs
@@ -71,7 +71,7 @@ public class LocationTrackingService : Service, global::Android.Locations.ILocat
     private const long WakePhaseIntervalMs = 1000;   // 1s - match HighPerformance, gather all samples
     private const long MinSleepIntervalMs = 60000;   // 60s - minimum sleep interval
     private const long StoredSampleIntervalMs = 30000; // 30s - poll for TryLog when sample stored (no GPS)
-    private const int WakeBufferSeconds = 90;        // Wake up 90s before threshold
+    private const int WakeBufferSeconds = 100;       // Wake up 100s before threshold (enough for cold start GPS)
     private const int StaleSampleBufferSeconds = 5;  // Extra buffer before clearing stale sample
 
     // Two-tier accuracy thresholds for wake phase:


### PR DESCRIPTION
## Summary
Increases the GPS wake buffer from 90s to 100s to provide additional margin for cold start GPS scenarios (phone reboot, very poor indoor conditions).

## Changes
- `LocationTrackingService.cs`: Changed `WakeBufferSeconds` from 90 to 100
- `05-Location-Tracking.md`: Updated timing diagram and phase descriptions
- `12-Services.md`: Updated phase timing table

## Rationale
- Cold start GPS typically takes 45-90s to acquire a fix
- 100s provides ~10s margin for worst-case scenarios
- Early GPS shutoff (at ≤20m accuracy) means GPS is typically only active 5-10s per cycle
- The extra 10s buffer has negligible battery impact due to early shutoff optimization

## Test plan
- [ ] Verify GPS wake phase starts 100s before threshold
- [ ] Verify approach phase spans 100-200s before threshold
- [ ] Verify deep sleep phase is >200s before threshold
- [ ] Cold start scenario: reboot phone, verify GPS acquires fix within buffer