### PR TITLE
fix: restore group member markers when returning to Groups page

### DIFF
--- a/src/WayfarerMobile/ViewModels/GroupsViewModel.cs
+++ b/src/WayfarerMobile/ViewModels/GroupsViewModel.cs
@@ -2219,11 +2219,19 @@ public partial class GroupsViewModel : BaseViewModel
         {
             await LoadGroupsAsync();
         }
-        else if (SelectedGroup != null && IsToday)
+        else if (SelectedGroup != null)
         {
-            // Resume SSE subscriptions when returning to the page
-            // Fire and forget - don't block page appearing
-            _ = StartSseSubscriptionsAsync();
+            // Returning to page - restore markers that were cleared in OnDisappearingAsync
+            if (IsMapView)
+            {
+                UpdateMapMarkers();
+            }
+
+            // Resume SSE subscriptions for live updates (only when viewing today)
+            if (IsToday)
+            {
+                _ = StartSseSubscriptionsAsync();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes issue where group member markers don't show when returning to Groups page after visiting other pages

## Root Cause
`OnDisappearingAsync` clears map markers to free memory, but `OnAppearingAsync` only started SSE subscriptions without restoring the cleared markers.

## Fix
Call `UpdateMapMarkers()` in `OnAppearingAsync` when returning to the page with a selected group. This restores the markers from the still-populated `Members` collection.

## Test plan
- [ ] Open Groups page - verify markers show
- [ ] Navigate to another page (e.g., Main map)
- [ ] Return to Groups page
- [ ] Verify markers show correctly

Fixes #94