### PR TITLE
docs: add refactoring context to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,3 +87,57 @@ See `docs/reference/NAVIGATION_SYSTEM.md` for full documentation.
 - No business logic in code-behind (code-behind may contain only UI-specific behaviors such as map gestures and animations).
 - Prefer CommunityToolkit.Mvvm attributes: `[ObservableProperty]`, `[RelayCommand]`.
 - Use Syncfusion components where they provide clear value and reduce custom UI complexity.
+
+## Active Refactoring: Issues #75, #76, #77
+
+**IMPORTANT: Read this section before any work on these issues.**
+
+A large-scale refactoring is in progress. Issue #93 is the **master orchestration document** - always check it first for current status, phase order, and rules.
+
+### Quick Reference
+
+| Issue | Scope | Status |
+|-------|-------|--------|
+| #93 | Master orchestration (READ FIRST) | Open |
+| #77 | TripSyncService + TripDownloadService → 6 Services | Open |
+| #76 | TripsViewModel → 3 ViewModels | Open |
+| #75 | MainViewModel → 4 ViewModels | Open |
+
+### Branch Strategy
+
+```
+main (stable) ──► DO NOT commit refactoring work here
+  │
+  └── develop (integration branch) ──► All refactoring merges here first
+        │
+        └── feature/refactor-* ──► Individual phase branches
+```
+
+### Mandatory Rules
+
+1. **All refactoring branches base off `develop`**, not `main`
+2. **All refactoring PRs target `develop`**, not `main`
+3. **Phase order is STRICT**: Phase 0 → #77 → #76 → #75 (dependencies block progress)
+4. **Hotfix forward-merge**: If ANY change lands on `main`, immediately merge `main` → `develop`
+5. **Check #93** for current phase status before starting work
+
+### Phase Dependencies
+
+```
+Phase 0 (infrastructure) ──► BLOCKING
+    │
+    ├── ITripStateManager (replaces static CurrentLoadedTripId)
+    ├── CompositeDisposable pattern
+    ├── Characterization tests
+    └── Race condition fixes
+    │
+    ▼
+Phase 1: #77 Services ──► Phase 2: #76 TripsViewModel ──► Phase 3: #75 MainViewModel
+```
+
+### Before Starting Work
+
+1. `git fetch origin`
+2. Check which phase is active in #93
+3. Ensure you're on `develop` or a feature branch based on `develop`
+4. Verify previous phase is complete (check #93 progress tracking)


### PR DESCRIPTION
## Summary
Adds refactoring context to CLAUDE.md so future Claude sessions automatically know about the active refactoring effort.

## What's Added
- Quick reference table for issues #75, #76, #77, #93
- Branch strategy diagram (main → develop → feature branches)
- Mandatory rules (phase order, hotfix forward-merge, PR targets)
- Phase dependencies visualization
- Pre-work checklist

## Why This Matters
Without this, each new Claude session would need to be re-briefed on the refactoring plan, risking:
- Work on wrong branch (main instead of develop)
- Skipping phases or breaking dependency order
- Missing the hotfix forward-merge rule
- Duplicating analysis already in #93

## Test plan
- [x] CLAUDE.md renders correctly in GitHub
- [x] Information matches #93 orchestration issue