### PR TITLE
fix(#129): additional download fixes for bounding box and resume

### DIFF
--- a/src/WayfarerMobile.Core/Models/TripModels.cs
+++ b/src/WayfarerMobile.Core/Models/TripModels.cs
@@ -51,7 +51,9 @@ public class TripSummary
 
     /// <summary>
     /// Gets or sets the bounding box.
+    /// Server sends as "boundingBox".
     /// </summary>
+    [JsonPropertyName("boundingBox")]
     public BoundingBox? BoundingBox { get; set; }
 
     /// <summary>
@@ -174,7 +176,9 @@ public class TripDetails : INotifyPropertyChanged
 
     /// <summary>
     /// Gets or sets the bounding box.
+    /// Server sends as "boundingBox".
     /// </summary>
+    [JsonPropertyName("boundingBox")]
     public BoundingBox? BoundingBox { get; set; }
 
     /// <summary>

--- a/src/WayfarerMobile/Data/Repositories/DownloadStateRepository.cs
+++ b/src/WayfarerMobile/Data/Repositories/DownloadStateRepository.cs
@@ -53,9 +53,12 @@ public class DownloadStateRepository : RepositoryBase, IDownloadStateRepository
     public async Task<List<TripDownloadStateEntity>> GetPausedDownloadsAsync()
     {
         var db = await GetConnectionAsync();
+        // Include InProgress status to handle downloads interrupted by app kill/crash.
+        // Cancelled status is excluded because those get cleaned up.
         return await db.Table<TripDownloadStateEntity>()
             .Where(s => s.Status == DownloadStateStatus.Paused ||
-                       s.Status == DownloadStateStatus.LimitReached)
+                       s.Status == DownloadStateStatus.LimitReached ||
+                       s.Status == DownloadStateStatus.InProgress)
             .OrderByDescending(s => s.PausedAt)
             .ToListAsync();
     }

--- a/src/WayfarerMobile/ViewModels/TripDownloadViewModel.cs
+++ b/src/WayfarerMobile/ViewModels/TripDownloadViewModel.cs
@@ -644,6 +644,11 @@ public partial class TripDownloadViewModel : ObservableObject, IDisposable
             }
         }
 
+        // CRITICAL: Clear the processing flag BEFORE the long-running await
+        // The flag is meant to protect the brief initialization phase, not the entire download.
+        // Without this, pause attempts are blocked until the download completes.
+        _isProcessingPauseResume = false;
+
         try
         {
             var resumed = await _downloadService.ResumeDownloadAsync(tripId, _downloadCts.Token);


### PR DESCRIPTION
## Summary

Additional fixes for issue #129 (Full Download works) that were lost and recovered:

- Add `[JsonPropertyName("boundingBox")]` attribute to BoundingBox properties in TripSummary and TripDetails for correct server JSON deserialization
- Include `InProgress` status in `GetPausedDownloadsAsync` to handle downloads interrupted by app kill/crash
- Clear `_isProcessingPauseResume` flag before long-running await to allow pause attempts during active downloads

## Changes

| File | Change |
|------|--------|
| `TripModels.cs` | JsonPropertyName attribute on BoundingBox |
| `DownloadStateRepository.cs` | InProgress status in paused downloads query |
| `TripDownloadViewModel.cs` | Flag timing fix for pause/resume |

## Test plan

- [x] Build succeeds
- [x] All 2206 tests pass
- [ ] Manual test: Download trip, kill app mid-download, reopen - should show in paused list
- [ ] Manual test: During active download, pause should respond immediately

Relates to #129