### PR TITLE
perf: reduce sync rate limit from 65s to 12s and add drain loop (#101)

### DIFF
--- a/src/WayfarerMobile/App.xaml.cs
+++ b/src/WayfarerMobile/App.xaml.cs
@@ -194,11 +194,12 @@ public partial class App : Application
             if (queueDrainService != null)
             {
                 Action drainLoopStarter = () => queueDrainService.StartDrainLoop();
+                Func<bool> isRunningChecker = () => queueDrainService.IsDrainLoopRunning;
 
 #if ANDROID
-                WayfarerMobile.Platforms.Android.Services.LocationTrackingService.SetDrainLoopStarter(drainLoopStarter);
+                WayfarerMobile.Platforms.Android.Services.LocationTrackingService.SetDrainLoopStarter(drainLoopStarter, isRunningChecker);
 #elif IOS
-                WayfarerMobile.Platforms.iOS.Services.LocationTrackingService.SetDrainLoopStarter(drainLoopStarter);
+                WayfarerMobile.Platforms.iOS.Services.LocationTrackingService.SetDrainLoopStarter(drainLoopStarter, isRunningChecker);
 #endif
                 _logger.LogDebug("Drain loop starter wired to location services");
             }


### PR DESCRIPTION
## Summary
- Reduce sync rate limit from 65s to 12s for ~5x faster offline queue drain
- Add drain loop to QueueDrainService that keeps running until queue is empty
- Integrate drain loop trigger into Android/iOS background location services
- Wire up drain loop starter in App.xaml.cs during app startup

## Problem
When users return online after extended offline periods, the current 65s rate limiting results in slow sync times:
- 100 queued locations: 50 min → 17 min with 12s rate
- 1,000 queued locations: 8.3 hours → 2.8 hours
- 25,000 queued locations (max): 8.7 days → 2.9 days

Additionally, timer-based draining can stall when OS throttles background timer callbacks.

## Solution
1. **Rate limit reduction**: `MinSecondsBetweenDrains` from 65s to 12s (stays above server's 10s limit)
2. **Drain loop**: Continuous drain that runs until queue empty, respecting rate limits
3. **Background integration**: Each location queued triggers `StartDrainLoop()` via static Action delegate
4. **Safety guarantees**:
   - Single instance via `Interlocked.CompareExchange`
   - Fire-and-forget with full exception isolation
   - Exits on: queue empty, offline, too many failures, disposed

## Test plan
- [x] Build succeeds (0 warnings, 0 errors)
- [x] All 2261 tests pass
- [ ] Manual test: queue locations offline, verify faster sync when online
- [ ] Verify drain loop starts after each queued location
- [ ] Verify drain loop exits when queue is empty
- [ ] Verify rate limiting is respected (12s between drains)

Closes #101