### PR TITLE
fix: populate metadata fields in online location submission path

### DIFF
--- a/src/WayfarerMobile/App.xaml.cs
+++ b/src/WayfarerMobile/App.xaml.cs
@@ -260,7 +260,7 @@ public partial class App : Application
             if (apiClient == null)
                 throw new InvalidOperationException("API client not available");
 
-            // Convert to API request model
+            // Convert to API request model with metadata
             var request = new LocationLogRequest
             {
                 Latitude = location.Latitude,
@@ -268,7 +268,18 @@ public partial class App : Application
                 Accuracy = location.Accuracy,
                 Altitude = location.Altitude,
                 Speed = location.Speed,
-                Timestamp = location.Timestamp
+                Timestamp = location.Timestamp,
+                Provider = location.Provider,
+                Bearing = location.Bearing,
+                // Metadata fields - captured at submission time
+                Source = "mobile-log",
+                IsUserInvoked = false,
+                AppVersion = DeviceMetadataHelper.GetAppVersion(),
+                AppBuild = DeviceMetadataHelper.GetAppBuild(),
+                DeviceModel = DeviceMetadataHelper.GetDeviceModel(),
+                OsVersion = DeviceMetadataHelper.GetOsVersion(),
+                BatteryLevel = DeviceMetadataHelper.GetBatteryLevel(),
+                IsCharging = DeviceMetadataHelper.GetIsCharging()
             };
 
             // Call the log-location endpoint (server is authoritative)


### PR DESCRIPTION
## Summary

- Fix missing metadata fields when submitting locations via the online path (direct API call)
- Add all metadata fields to `LocationLogRequest` in `onlineSubmit` delegate using `DeviceMetadataHelper`

## Problem

The `onlineSubmit` delegate in `App.xaml.cs` was creating `LocationLogRequest` with only basic location fields, missing all metadata:
- `Source`, `IsUserInvoked`, `Provider`, `Bearing`
- `AppVersion`, `AppBuild`, `DeviceModel`, `OsVersion`
- `BatteryLevel`, `IsCharging`

This caused locations submitted when online to have null metadata, while the offline queue path correctly populated metadata.

## Root Cause

After PR stef-k/Wayfarer#121 added metadata fields to the backend, the mobile app's offline path (`LocationQueueRepository.QueueLocationAsync`) was updated to populate metadata via `DeviceMetadataHelper`, but the online path (`onlineSubmit` delegate) was not updated.

## Fix

Updated `App.xaml.cs` to populate all metadata fields in the `onlineSubmit` delegate, matching the offline path behavior.

## Test Plan

- [x] Build succeeds
- [ ] Deploy to device and verify online location submissions include metadata
- [ ] Check backend database shows populated metadata fields for new locations

Fixes stef-k/Wayfarer#126