### PR TITLE
docs: update documentation for recent features (#183)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,18 @@ Wayfarer Mobile is a cross-platform .NET MAUI app for Android and iOS that serve
 | **Offline Maps** | Download map tiles (zoom 8-17) per trip for offline use |
 | **Turn-by-Turn Navigation** | Voice-guided navigation with multi-tier route fallback |
 | **Group Sharing** | Real-time location sharing via SSE with colored member markers |
-| **Activity Types** | 20 built-in activities with icons, server sync every 6 hours |
+| **Activity Types** | 20 built-in activities with icons, editable per-location, server sync every 6 hours |
 | **Manual Check-ins** | Quick location logging with activity type and notes |
 | **QR Setup** | Scan a QR code to instantly configure server connection |
 | **PIN Lock** | Protect your location data with app-level security |
+| **Queue Management** | Monitor sync status, configurable limits, export queue data |
 
 ### Key Highlights
 
 - **Offline-First Architecture**: Local SQLite storage with background sync, works without internet
 - **Smart Battery Usage**: Three-phase sleep/wake optimization for background tracking (~1-3% per hour)
 - **Dual Navigation Modes**: Trip navigation (user segments → cached → OSRM → direct) and ad-hoc navigation (OSRM → direct)
-- **Queue Resilience**: Up to 25,000 locations queued locally, syncs when online with retry
+- **Queue Resilience**: Configurable queue limit (default 25,000), fast sync (12s/location), export to CSV/GeoJSON
 
 ## Quick Start
 

--- a/docs/docsify/03-Features.md
+++ b/docs/docsify/03-Features.md
@@ -67,11 +67,24 @@ Tap any entry to see:
 ### Editing Timeline Entries
 
 1. Tap an entry to open details
-2. Tap **Edit**
-3. Modify date/time, activity type, or notes
-4. Tap **Save**
+2. Tap **Edit** to modify:
+   - **Date/Time**: Adjust the timestamp
+   - **Notes**: Add or update notes
+3. Tap **Save**
 
 > **Note**: Coordinates cannot be edited as they are GPS data.
+
+### Editing Activity Types
+
+Timeline entries can have an activity type assigned:
+
+1. Tap an entry to open details
+2. Tap **Edit Activity**
+3. In the activity picker popup:
+   - Select an activity from the list
+   - Tap **Refresh** to sync latest activities from server
+   - Tap **Clear** to remove the activity assignment
+4. Changes sync to server automatically (or queue if offline)
 
 ### Exporting Timeline Data
 
@@ -456,6 +469,42 @@ Configure app behavior in the Settings page.
 - **Distance threshold**: Minimum meters between logged locations
 
 > **Note**: Thresholds are set by your server and sync automatically.
+
+### Offline Queue
+
+Manage the local queue of locations waiting to sync to the server.
+
+**Queue Status Display:**
+| Field | Description |
+|-------|-------------|
+| Total | All queued locations |
+| Pending | Waiting to sync |
+| Retrying | Failed sync attempts being retried |
+| Synced | Successfully sent to server |
+| Rejected | Server rejected (invalid data) |
+| Health | Overall queue health (Healthy/Warning/Critical/Over Limit) |
+
+**Queue Limit:**
+- Configurable from 1 to 100,000 locations (default: 25,000)
+- Storage warning shown above 50,000
+- Coverage estimate shows how much time the current queue spans
+- Headroom shows estimated time until queue fills
+
+**Export Options:**
+- **CSV**: Export all queued locations to CSV format
+- **GeoJSON**: Export as geographic data for mapping tools
+
+**Clear Actions:**
+| Action | What It Clears |
+|--------|----------------|
+| Clear Synced | Synced + rejected locations (safe to clear) |
+| Clear Pending | Unsynced locations (data loss warning) |
+| Clear All | Entire queue (confirmation required) |
+
+**Rolling Buffer Cleanup:**
+When the queue reaches its limit, automatic cleanup runs:
+1. First removes synced/rejected entries
+2. Then removes oldest pending entries (never entries currently syncing)
 
 ### Map Cache
 

--- a/docs/docsify/07-Troubleshooting.md
+++ b/docs/docsify/07-Troubleshooting.md
@@ -122,8 +122,12 @@ For detailed troubleshooting:
 1. **Check internet connection**
 2. **Verify server URL**: Settings > Account > Server URL
 3. **Check authentication**: Try logging out and back in
-4. **View queue status**: Diagnostics > Location Queue
-5. **Check server status**: Is the server online?
+4. **View queue status**: Settings > Offline Queue (shows detailed breakdown)
+5. **Check for rejected entries**: High rejected count may indicate server issues
+6. **Export queue for debugging**: Settings > Offline Queue > Export CSV
+7. **Check server status**: Is the server online?
+
+> **Tip**: The Offline Queue section in Settings shows health status, sync rate, and detailed breakdowns of pending/synced/rejected counts.
 
 ### No Locations Being Logged
 
@@ -353,9 +357,11 @@ If QR scanning doesn't work:
 **Solutions:**
 
 1. **Check date filter**: May be viewing wrong day
-2. **Wait for sync**: Data may not have synced yet
+2. **Wait for sync**: Data may not have synced yet (~12s per location)
 3. **Check tracking was enabled**: No logging = no data
-4. **Verify server has data**: Check web app timeline
+4. **Check queue status**: Settings > Offline Queue shows pending count
+5. **Verify server has data**: Check web app timeline
+6. **Check for rejected entries**: Some locations may have been filtered out
 
 ### Check-In Failed
 


### PR DESCRIPTION
## Summary
- Added Settings > Offline Queue documentation covering status display, configurable limits, CSV/GeoJSON export, and clear actions (PR #179)
- Documented Timeline activity editing with picker popup, refresh, and clear functionality (PR #176)
- Updated sync rate from 65s to 12s per location in queue/services docs (PR #168)
- Replaced LocationSyncService with QueueDrainService in services documentation
- Added TimelineSyncService background processing details (PR #178)
- Updated troubleshooting with queue management tips and references
- Updated README features table with queue management and activity editing

## Test plan
- [ ] Review docsify documentation renders correctly
- [ ] Verify all feature descriptions match current implementation
- [ ] Check cross-references between documentation pages

Closes #183