### PR TITLE
chore: reduce log verbosity for production release

### DIFF
--- a/src/WayfarerMobile.Core/Services/VisitNotificationService.cs
+++ b/src/WayfarerMobile.Core/Services/VisitNotificationService.cs
@@ -169,7 +169,7 @@ public class VisitNotificationService : IVisitNotificationService
             // Create cancellation token for subscription
             _subscriptionCts = new CancellationTokenSource();
 
-            _logger.LogInformation("Starting visit SSE subscription");
+            _logger.LogDebug("Starting visit SSE subscription");
 
             // Start subscription in background (fire-and-forget)
             _ = Task.Run(async () =>
@@ -198,7 +198,7 @@ public class VisitNotificationService : IVisitNotificationService
     /// <inheritdoc />
     public void Stop()
     {
-        _logger.LogInformation("Stopping visit notification service");
+        _logger.LogDebug("Stopping visit notification service");
         UnsubscribeFromSyncEvents();
         CleanupClient();
     }
@@ -285,7 +285,7 @@ public class VisitNotificationService : IVisitNotificationService
         // Determine notification mode based on navigation state
         var mode = DetermineNotificationMode(visit);
 
-        _logger.LogInformation(
+        _logger.LogDebug(
             "Visit notification: {PlaceName} in {TripName}, mode={Mode}",
             visit.PlaceName, visit.TripName, mode);
 
@@ -608,12 +608,12 @@ public class VisitNotificationService : IVisitNotificationService
 
     private void OnConnected(object? sender, EventArgs e)
     {
-        _logger.LogInformation("Visit SSE connected");
+        _logger.LogDebug("Visit SSE connected");
     }
 
     private void OnReconnecting(object? sender, SseReconnectEventArgs e)
     {
-        _logger.LogInformation(
+        _logger.LogDebug(
             "Visit SSE reconnecting: attempt {Attempt}, delay {Delay}ms",
             e.Attempt, e.DelayMs);
     }

--- a/src/WayfarerMobile/MainPage.xaml.cs
+++ b/src/WayfarerMobile/MainPage.xaml.cs
@@ -347,7 +347,7 @@ public partial class MainPage : ContentPage, IQueryAttributable
         }
 
         // All conditions met - signal readiness
-        _logger.LogInformation("TrySetPageReady: All conditions met, signaling page ready");
+        _logger.LogDebug("TrySetPageReady: All conditions met, signaling page ready");
         _pageReadyTcs.TrySetResult();
     }
 
@@ -421,7 +421,7 @@ public partial class MainPage : ContentPage, IQueryAttributable
         // Clear pending trip now that we're committed to loading
         _pendingTrip = null;
 
-        _logger.LogInformation("LoadPendingTripIfReadyAsync: Readiness gate passed, loading trip {TripName}", trip.Name);
+        _logger.LogDebug("LoadPendingTripIfReadyAsync: Readiness gate passed, loading trip {TripName}", trip.Name);
         await _viewModel.LoadTripForNavigationAsync(trip);
         _logger.LogDebug("LoadPendingTripIfReadyAsync: After load, HasLoadedTrip={HasLoaded}", _viewModel.HasLoadedTrip);
     }

--- a/src/WayfarerMobile/MauiProgram.cs
+++ b/src/WayfarerMobile/MauiProgram.cs
@@ -90,6 +90,7 @@ public static class MauiProgram
 #endif
             .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
             .MinimumLevel.Override("System", LogEventLevel.Warning)
+            .MinimumLevel.Override("Microsoft.Maui.Controls.Element", LogEventLevel.Error) // Suppress Syncfusion binding warnings
             .Enrich.FromLogContext()
             .Enrich.WithProperty("Application", "WayfarerMobile")
             .WriteTo.File(

--- a/src/WayfarerMobile/Services/ExceptionHandlerService.cs
+++ b/src/WayfarerMobile/Services/ExceptionHandlerService.cs
@@ -32,7 +32,7 @@ public class ExceptionHandlerService : IExceptionHandlerService
         TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
 
         _isInitialized = true;
-        _logger.LogInformation("Global exception handler initialized");
+        _logger.LogDebug("Global exception handler initialized");
     }
 
     /// <inheritdoc/>

--- a/src/WayfarerMobile/Services/LocalTimelineStorageService.cs
+++ b/src/WayfarerMobile/Services/LocalTimelineStorageService.cs
@@ -91,13 +91,13 @@ public class LocalTimelineStorageService : IDisposable
                     Provider = lastEntry.Provider
                 };
                 _filter.Initialize(lastLocation);
-                _logger.LogInformation(
+                _logger.LogDebug(
                     "Initialized filter with last stored location from {Timestamp:u}",
                     lastEntry.Timestamp);
             }
             else
             {
-                _logger.LogInformation("No previous timeline entries found, filter will accept first location");
+                _logger.LogDebug("No previous timeline entries found, filter will accept first location");
             }
 
             // Subscribe to events BEFORE running recovery to avoid missing new events
@@ -112,7 +112,7 @@ public class LocalTimelineStorageService : IDisposable
             await BackfillMissedQueueEntriesAsync();
 
             _isInitialized = true;
-            _logger.LogInformation("LocalTimelineStorageService initialized");
+            _logger.LogDebug("LocalTimelineStorageService initialized");
         }
         catch (SQLiteException ex)
         {
@@ -185,7 +185,7 @@ public class LocalTimelineStorageService : IDisposable
 
             if (reconciled > 0)
             {
-                _logger.LogInformation(
+                _logger.LogDebug(
                     "EDGE-14 reconciliation: Updated {Count} local entries with missing ServerId",
                     reconciled);
             }
@@ -323,7 +323,7 @@ public class LocalTimelineStorageService : IDisposable
 
             if (backfilled > 0 || filtered > 0)
             {
-                _logger.LogInformation(
+                _logger.LogDebug(
                     "EDGE-1 backfill: Created {Backfilled} local timeline entries from queue ({Filtered} filtered)",
                     backfilled, filtered);
             }
@@ -546,7 +546,7 @@ public class LocalTimelineStorageService : IDisposable
     public void ResetFilter()
     {
         _filter.Reset();
-        _logger.LogInformation("Local timeline filter reset");
+        _logger.LogDebug("Local timeline filter reset");
     }
 
     /// <summary>

--- a/src/WayfarerMobile/Services/QueueDrainService.cs
+++ b/src/WayfarerMobile/Services/QueueDrainService.cs
@@ -197,7 +197,7 @@ public sealed class QueueDrainService : IDisposable
 
         try
         {
-            _logger.LogInformation("Starting QueueDrainService");
+            _logger.LogDebug("Starting QueueDrainService");
 
             // Initialize: validate reference point and reset stuck locations
             await InitializeAsync();
@@ -226,7 +226,7 @@ public sealed class QueueDrainService : IDisposable
                 TimeSpan.FromHours(CleanupIntervalHours));
 
             _isStarted = true;
-            _logger.LogInformation("QueueDrainService started successfully");
+            _logger.LogDebug("QueueDrainService started successfully");
         }
         catch (Exception ex)
         {
@@ -242,7 +242,7 @@ public sealed class QueueDrainService : IDisposable
         if (!_isStarted)
             return;
 
-        _logger.LogInformation("Stopping QueueDrainService");
+        _logger.LogDebug("Stopping QueueDrainService");
 
         // Cancel any pending timer callbacks first
         _timerCts?.Cancel();
@@ -260,7 +260,7 @@ public sealed class QueueDrainService : IDisposable
         _timerCts = null;
 
         _isStarted = false;
-        _logger.LogInformation("QueueDrainService stopped");
+        _logger.LogDebug("QueueDrainService stopped");
     }
 
     /// <summary>
@@ -468,13 +468,13 @@ public sealed class QueueDrainService : IDisposable
 
             if (!wasOnline && _isOnline)
             {
-                _logger.LogInformation("Network restored, queue drain will resume");
+                _logger.LogDebug("Network restored, queue drain will resume");
                 // Reset consecutive failures on network restore
                 Interlocked.Exchange(ref _consecutiveFailures, 0);
             }
             else if (wasOnline && !_isOnline)
             {
-                _logger.LogInformation("Network lost, queue drain paused");
+                _logger.LogDebug("Network lost, queue drain paused");
             }
         }
         catch (Exception ex)

--- a/src/WayfarerMobile/Services/TimelineSyncService.cs
+++ b/src/WayfarerMobile/Services/TimelineSyncService.cs
@@ -198,7 +198,7 @@ public sealed class TimelineSyncService : ITimelineSyncService
 
         try
         {
-            _logger.LogInformation("Starting TimelineSyncService");
+            _logger.LogDebug("Starting TimelineSyncService");
 
             // Ensure database is initialized
             await EnsureInitializedAsync();
@@ -220,7 +220,7 @@ public sealed class TimelineSyncService : ITimelineSyncService
                 TimeSpan.FromSeconds(TimerIntervalSeconds));
 
             _isStarted = true;
-            _logger.LogInformation("TimelineSyncService started successfully");
+            _logger.LogDebug("TimelineSyncService started successfully");
         }
         catch (Exception ex)
         {
@@ -236,7 +236,7 @@ public sealed class TimelineSyncService : ITimelineSyncService
         if (!_isStarted)
             return;
 
-        _logger.LogInformation("Stopping TimelineSyncService");
+        _logger.LogDebug("Stopping TimelineSyncService");
 
         // Cancel any pending timer callbacks first
         _timerCts?.Cancel();
@@ -250,7 +250,7 @@ public sealed class TimelineSyncService : ITimelineSyncService
         _timerCts = null;
 
         _isStarted = false;
-        _logger.LogInformation("TimelineSyncService stopped");
+        _logger.LogDebug("TimelineSyncService stopped");
     }
 
     /// <summary>
@@ -324,7 +324,7 @@ public sealed class TimelineSyncService : ITimelineSyncService
 
             if (!wasOnline && _isOnline)
             {
-                _logger.LogInformation("Network restored, timeline sync will resume");
+                _logger.LogDebug("Network restored, timeline sync will resume");
                 // Reset consecutive failures on network restore
                 Interlocked.Exchange(ref _consecutiveFailures, 0);
 
@@ -333,7 +333,7 @@ public sealed class TimelineSyncService : ITimelineSyncService
             }
             else if (wasOnline && !_isOnline)
             {
-                _logger.LogInformation("Network lost, timeline sync paused");
+                _logger.LogDebug("Network lost, timeline sync paused");
             }
         }
         catch (Exception ex)

--- a/src/WayfarerMobile/Services/TripLayerService.cs
+++ b/src/WayfarerMobile/Services/TripLayerService.cs
@@ -114,12 +114,12 @@ public class TripLayerService : ITripLayerService
         layer.Clear();
 
         var areaList = areas.ToList();
-        _logger.LogInformation("UpdateTripAreas called with {Count} areas", areaList.Count);
+        _logger.LogDebug("UpdateTripAreas called with {Count} areas", areaList.Count);
 
         var areaCount = 0;
         foreach (var area in areaList)
         {
-            _logger.LogInformation("Processing area '{Name}': GeometryGeoJson={HasGeo}, Boundary={BoundaryCount} pts, Fill={Fill}",
+            _logger.LogDebug("Processing area '{Name}': GeometryGeoJson={HasGeo}, Boundary={BoundaryCount} pts, Fill={Fill}",
                 area.Name,
                 !string.IsNullOrEmpty(area.GeometryGeoJson) ? $"yes({area.GeometryGeoJson.Length} chars)" : "null",
                 area.Boundary?.Count ?? 0,
@@ -180,7 +180,7 @@ public class TripLayerService : ITripLayerService
 
                 layer.Add(feature);
                 areaCount++;
-                _logger.LogInformation("Successfully added area '{Name}' to layer", area.Name);
+                _logger.LogDebug("Successfully added area '{Name}' to layer", area.Name);
             }
             catch (Exception ex)
             {
@@ -205,7 +205,7 @@ public class TripLayerService : ITripLayerService
         layer.Clear();
 
         var segmentList = segments.ToList();
-        _logger.LogInformation("UpdateTripSegments called with {Count} segments", segmentList.Count);
+        _logger.LogDebug("UpdateTripSegments called with {Count} segments", segmentList.Count);
 
         var segmentCount = 0;
         foreach (var segment in segmentList)

--- a/src/WayfarerMobile/ViewModels/MainViewModel.cs
+++ b/src/WayfarerMobile/ViewModels/MainViewModel.cs
@@ -1121,7 +1121,7 @@ public partial class MainViewModel : BaseViewModel, IMapDisplayCallbacks, INavig
     public async Task LoadTripForNavigationAsync(TripDetails tripDetails)
     {
         // Issue #185 instrumentation: Log visibility state to help diagnose crashes
-        _logger.LogInformation("Loading trip: {TripName} ({PlaceCount} places, {SegmentCount} segments, {AreaCount} areas), IsPageVisible={IsVisible}",
+        _logger.LogDebug("Loading trip: {TripName} ({PlaceCount} places, {SegmentCount} segments, {AreaCount} areas), IsPageVisible={IsVisible}",
             tripDetails.Name, tripDetails.AllPlaces.Count, tripDetails.Segments.Count, tripDetails.AllAreas.Count, _isPageVisible);
 
         // Debug: Log regions and their areas
@@ -1157,7 +1157,7 @@ public partial class MainViewModel : BaseViewModel, IMapDisplayCallbacks, INavig
         {
             MapDisplay.ZoomToPoints(placePoints);
             MapDisplay.IsFollowingLocation = false; // Don't auto-center on user location
-            _logger.LogInformation("Zoomed map to fit {Count} trip places", placePoints.Count);
+            _logger.LogDebug("Zoomed map to fit {Count} trip places", placePoints.Count);
         }
         else if (tripDetails.BoundingBox != null)
         {
@@ -1167,7 +1167,7 @@ public partial class MainViewModel : BaseViewModel, IMapDisplayCallbacks, INavig
             var centerLon = (bb.East + bb.West) / 2;
             MapDisplay.CenterOnLocation(centerLat, centerLon, zoomLevel: 12);
             MapDisplay.IsFollowingLocation = false;
-            _logger.LogInformation("Centered map on trip bounding box center");
+            _logger.LogDebug("Centered map on trip bounding box center");
         }
 
         // Force map refresh to ensure layers are rendered

--- a/src/WayfarerMobile/ViewModels/SseManagementViewModel.cs
+++ b/src/WayfarerMobile/ViewModels/SseManagementViewModel.cs
@@ -170,7 +170,7 @@ public class SseManagementViewModel : IDisposable
         _groupSseClient.Reconnecting += OnSseReconnecting;
         _groupSseClient.PermanentError += OnSsePermanentError;
 
-        _logger.LogInformation("Starting SSE subscription for group {GroupId}", groupIdString);
+        _logger.LogDebug("Starting SSE subscription for group {GroupId}", groupIdString);
 
         // Start subscription in background (fire and forget)
         _ = Task.Run(async () =>
@@ -391,7 +391,7 @@ public class SseManagementViewModel : IDisposable
                 case "invite-declined":
                 case "invite-revoked":
                     // These are informational - no UI action needed
-                    _logger.LogInformation("Invite event: {Action}", membership.Action);
+                    _logger.LogDebug("Invite event: {Action}", membership.Action);
                     break;
 
                 default:
@@ -419,7 +419,7 @@ public class SseManagementViewModel : IDisposable
         if (_isDisposed || _callbacks == null || _callbacks.IsDisposed)
             return;
 
-        _logger.LogInformation("SSE invite created: {InvitationId}", e.InviteCreated.InvitationId);
+        _logger.LogDebug("SSE invite created: {InvitationId}", e.InviteCreated.InvitationId);
         // Future: Could refresh pending invitations list if UI is added
     }
 
@@ -428,7 +428,7 @@ public class SseManagementViewModel : IDisposable
     /// </summary>
     private void OnSseConnected(object? sender, EventArgs e)
     {
-        _logger.LogInformation("SSE connected");
+        _logger.LogDebug("SSE connected");
     }
 
     /// <summary>
@@ -436,7 +436,7 @@ public class SseManagementViewModel : IDisposable
     /// </summary>
     private void OnSseReconnecting(object? sender, SseReconnectEventArgs e)
     {
-        _logger.LogInformation("SSE reconnecting (attempt {Attempt}, delay {DelayMs}ms)", e.Attempt, e.DelayMs);
+        _logger.LogDebug("SSE reconnecting (attempt {Attempt}, delay {DelayMs}ms)", e.Attempt, e.DelayMs);
     }
 
     /// <summary>
@@ -491,7 +491,7 @@ public class SseManagementViewModel : IDisposable
                     _callbacks.UpdateMapMarkers();
                 }
 
-                _logger.LogInformation("Updated peer visibility for {UserId}: disabled={Disabled}", userId, isDisabled);
+                _logger.LogDebug("Updated peer visibility for {UserId}: disabled={Disabled}", userId, isDisabled);
             }
         });
     }
@@ -517,7 +517,7 @@ public class SseManagementViewModel : IDisposable
                     _callbacks.UpdateMapMarkers();
                 }
 
-                _logger.LogInformation("Removed member {UserId} from group", userId);
+                _logger.LogDebug("Removed member {UserId} from group", userId);
             }
         });
     }


### PR DESCRIPTION
## Summary

- Change INFO-level logs to DEBUG for routine operations that create noise in production
- Add Syncfusion binding warning filter to Serilog configuration

## Changes

**Services updated (INFO → DEBUG):**
- `QueueDrainService` - Starting/stopping, network state changes
- `TimelineSyncService` - Starting/stopping, network state changes
- `SseClient` - Connecting, reconnecting, event handling (location, membership, invite)
- `VisitNotificationService` - Starting/stopping, SSE connected/reconnecting, visit notifications
- `TripLayerService` - Area/segment layer updates
- `LocalTimelineStorageService` - Filter initialization, backfill, reconciliation
- `ExceptionHandlerService` - Initialization

**ViewModels updated (INFO → DEBUG):**
- `MainViewModel` - Trip loading, map zoom operations
- `SseManagementViewModel` - SSE subscription start, connection events, invite events

**Pages updated (INFO → DEBUG):**
- `MainPage` - Page readiness checks, trip loading gate

**Serilog configuration:**
- Added `.MinimumLevel.Override("Microsoft.Maui.Controls.Element", LogEventLevel.Error)` to suppress Syncfusion binding warnings

## Test plan

- [ ] Verify app starts and operates normally
- [ ] Verify logs in release build are less verbose
- [ ] Verify errors/warnings still appear in logs
- [ ] Verify SSE connection failures are still logged (warning level)