### PR TITLE
fix: ensure map center always zooms to specified level

### DIFF
--- a/src/WayfarerMobile/ViewModels/MapDisplayViewModel.cs
+++ b/src/WayfarerMobile/ViewModels/MapDisplayViewModel.cs
@@ -200,11 +200,9 @@ public partial class MapDisplayViewModel : BaseViewModel
         }
         else
         {
-            // No location available - show globe view (zoom 2)
-            if (map.Navigator.Resolutions?.Count > 2)
-            {
-                map.Navigator.ZoomTo(map.Navigator.Resolutions[2]);
-            }
+            // No location available - show globe view centered on Atlantic (zoom 2)
+            // Using 0,0 as center point shows a balanced world view
+            _mapBuilder.CenterOnLocation(map, 0, 0, zoomLevel: 2);
             _logger.LogDebug("Map initialized at globe view (no location available)");
         }
     }

--- a/src/WayfarerMobile/ViewModels/TimelineViewModel.cs
+++ b/src/WayfarerMobile/ViewModels/TimelineViewModel.cs
@@ -489,13 +489,12 @@ public partial class TimelineViewModel : BaseViewModel, ICoordinateEditorCallbac
                 {
                     _mapBuilder.ZoomToPoints(_map, points);
                 }
-                else
+                else if (_map != null)
                 {
-                    _map?.Navigator.CenterOn(points[0]);
-                    if (_map?.Navigator.Resolutions?.Count > 15)
-                    {
-                        _map.Navigator.ZoomTo(_map.Navigator.Resolutions[15]);
-                    }
+                    // Single point - center and zoom to street level
+                    var point = points[0];
+                    var (lon, lat) = SphericalMercator.ToLonLat(point.X, point.Y);
+                    _mapBuilder.CenterOnLocation(_map, lat, lon, zoomLevel: 15);
                 }
             });
         }


### PR DESCRIPTION
## Summary

Fixes intermittent issue where the FAB "center on user" button would center the map but not zoom to street level.

## Root Cause

In Mapsui 5.0+, `map.Navigator.Resolutions` can be null or empty when no limiter is configured. The previous code:

```csharp
if (zoomLevel.HasValue && map.Navigator.Resolutions?.Count > zoomLevel.Value)
{
    map.Navigator.ZoomTo(map.Navigator.Resolutions[zoomLevel.Value]);
}
```

Would silently skip zooming when `Resolutions` was unavailable.

## Solution

Calculate resolution directly using the standard OSM/Web Mercator formula:

```
resolution = 156543.03392 / 2^zoomLevel
```

This works independently of Mapsui's Navigator state.

## Changes

**MapBuilder.cs:**
- Calculate resolution directly instead of using `Navigator.Resolutions`
- Add null map guard with warning log
- Add coordinate validation (clamp to Web Mercator bounds: ±85.05° lat, ±180° lon)
- Add zoom level clamping (0-20) to prevent extreme values
- Wrap in try-catch for production robustness
- Extract constants for reuse (`MaxResolutionAtZoom0`, `MinZoomLevel`, `MaxZoomLevel`)

**MapDisplayViewModel.cs:**
- Update globe view initialization to use `CenterOnLocation(0, 0, zoomLevel: 2)`

**TimelineViewModel.cs:**
- Update single-point zoom to use `CenterOnLocation` instead of direct `Navigator.Resolutions` access

## Test plan

- [ ] Tap FAB center button - should center AND zoom to street level (zoom 16)
- [ ] Load app without location - should show globe view (zoom 2)
- [ ] View single timeline entry - should center and zoom to street level (zoom 15)
- [ ] Verify no crashes with edge case coordinates