### PR TITLE
docs: add privacy, security, and platform notes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Wayfarer Mobile is a cross-platform .NET MAUI app for Android and iOS that serve
 
 ### Privacy & Data Handling
 
-Wayfarer Mobile is a privacy-first companion app for Wayfarer. Location history is stored locally (SQLite) and synced only to your configured Wayfarer server. The app does not use third-party analytics or tracking by default. Background location tracking requires elevated OS permissions; review and configure tracking settings carefully before enabling continuous logging.
+Wayfarer Mobile is a privacy-first companion app for self-hosted Wayfarer servers. Location history is stored locally (SQLite) and synced only to your configured Wayfarer server. The app does not use third-party analytics or tracking by default. Background location tracking requires elevated OS permissions; review and configure tracking settings carefully before enabling continuous logging.
 
 ## Features
 


### PR DESCRIPTION
## Summary

Adds trust-building snippets to the README for open-source release, as suggested by the reviewer:

- **Privacy & Data Handling**: Added after intro - clarifies self-hosted design, local storage, no third-party analytics
- **Platform Permissions**: Added after Build & Run - summarizes Android/iOS background location requirements
- **Security Note**: Added after Connect to Server - reminds users to treat tokens like passwords
- **Offline Maps Note**: Added after Key Highlights - sets storage expectations with default cache limits

All additions align with and link to the existing detailed documentation in `docs/`.

## Test plan

- [x] Verify snippets match existing documentation content
- [x] Confirm markdown renders correctly
- [x] Check links to User Guide work