### PR TITLE
Fix THIRD-PARTY-NOTICES.txt per review feedback

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,5 +1,7 @@
 THIRD-PARTY NOTICES
 
+WayfarerMobile itself is MIT-licensed (see LICENSE.txt). This file lists third-party notices.
+
 This project incorporates components from the projects listed below. The original
 copyright notices and the licenses under which WayfarerMobile received such components
 are set forth below.
@@ -129,6 +131,7 @@ Licensed under the Apache License, Version 2.0.
 Based on ZXing.Net:
 https://github.com/micjahn/ZXing.Net
 Copyright (c) Michael Jahn
+Licensed under the Apache License, Version 2.0.
 
 --------------------------------------------------------------------------------
 
@@ -262,7 +265,7 @@ Copyright (c) Project OSRM contributors
 
 Licensed under the BSD 2-Clause License.
 
-Note: Routing service provided by Project OSRM's demo server.
+Note: Routing can be provided by an OSRM-compatible endpoint (demo or self-hosted).
 
 ================================================================================
 
@@ -364,16 +367,4 @@ POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-Copyright 2025 Stef Kariotidis / Wayfarer
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+This file compiled by Stef Kariotidis / Wayfarer, 2025.


### PR DESCRIPTION
## Summary

- Added MIT license clarification at the top stating the project is MIT-licensed
- Removed the errant Apache 2.0 license block at the bottom that made the notices file (or project) appear Apache-licensed
- Added missing Apache 2.0 license line for ZXing.Net base library
- Updated OSRM wording to be endpoint-agnostic ("demo or self-hosted")

## Test plan

- [x] Verify MIT clarification appears at the top
- [x] Verify no Apache license block at the bottom
- [x] Verify ZXing.Net section includes base library license
- [x] Verify OSRM wording is future-proof