### PR TITLE
Fix GPS high performance mode not applied at cold start

### DIFF
--- a/src/WayfarerMobile/ViewModels/MainViewModel.cs
+++ b/src/WayfarerMobile/ViewModels/MainViewModel.cs
@@ -1260,11 +1260,8 @@ public partial class MainViewModel : BaseViewModel, IMapDisplayCallbacks, INavig
 
         // Cache health is updated by CacheStatusService when location changes - NOT here on startup
 
-        // Set high performance mode for real-time updates when map is visible
-        if (Tracking.TrackingState == TrackingState.Active)
-        {
-            await Tracking.SetPerformanceModeCommand.ExecuteAsync(PerformanceMode.HighPerformance);
-        }
+        // Request high performance mode - applied when tracking becomes Active
+        await Tracking.RequestPerformanceModeAsync(PerformanceMode.HighPerformance);
 
         await base.OnAppearingAsync();
     }
@@ -1287,11 +1284,8 @@ public partial class MainViewModel : BaseViewModel, IMapDisplayCallbacks, INavig
             IsTripSheetOpen = false;
         }
 
-        // Set normal mode to conserve battery when map is not visible
-        if (Tracking.TrackingState == TrackingState.Active)
-        {
-            await Tracking.SetPerformanceModeCommand.ExecuteAsync(PerformanceMode.Normal);
-        }
+        // Request normal mode to conserve battery when map is not visible
+        await Tracking.RequestPerformanceModeAsync(PerformanceMode.Normal);
 
         await base.OnDisappearingAsync();
     }


### PR DESCRIPTION
## Summary
- Fixes #203: GPS HighPerformance mode never set at cold start because `OnAppearing` runs before tracking state sync
- Adds `RequestPerformanceModeAsync()` to `TrackingCoordinatorViewModel` that stores requested mode and applies it when tracking becomes Active
- Simplifies `MainViewModel.OnAppearingAsync/OnDisappearingAsync` by removing state checks (mode intent is declared, application is deferred)

## Test plan
- [ ] **Cold start**: Force-stop app, launch, verify logs show "Applying performance mode: HighPerformance" and GPS updates at ~1sec frequency
- [x] **Navigate away**: With tracking active, navigate to Settings, verify "Performance mode requested: Normal" in logs
- [x] **Hot navigation**: With tracking active, navigate away then back to MainPage, verify HighPerformance applied immediately