### PR TITLE
Add zoom level display and extend tile cache to z18

### DIFF
--- a/src/WayfarerMobile/MainPage.xaml
+++ b/src/WayfarerMobile/MainPage.xaml
@@ -80,6 +80,11 @@
                                        IsVisible="{Binding HasAltitude}"
                                        VerticalOptions="Center"
                                        TextColor="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray300}}" />
+                                <Label Text="{Binding ZoomLevelText}"
+                                       FontSize="11"
+                                       IsVisible="{Binding HasZoomLevel}"
+                                       VerticalOptions="Center"
+                                       TextColor="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray300}}" />
                                 <!-- Cache health indicator (tappable, larger hit area) -->
                                 <Border Padding="4,0" StrokeThickness="0" BackgroundColor="Transparent" VerticalOptions="Center">
                                     <Border.GestureRecognizers>

--- a/src/WayfarerMobile/Services/TileCache/TileCacheConstants.cs
+++ b/src/WayfarerMobile/Services/TileCache/TileCacheConstants.cs
@@ -14,14 +14,14 @@ public static class TileCacheConstants
     /// <summary>
     /// Maximum zoom level for tile caching (zoomed in, street detail).
     /// </summary>
-    public const int MaxZoomLevel = 17;
+    public const int MaxZoomLevel = 18;
 
     /// <summary>
     /// All zoom levels for full tile operations (prefetch, full status check, trip download).
     /// Ordered by priority: most commonly used navigation zoom levels first.
-    /// Range: 8-17 (10 zoom levels total).
+    /// Range: 8-18 (11 zoom levels total).
     /// </summary>
-    public static readonly int[] AllZoomLevels = { 15, 14, 16, 13, 12, 11, 10, 9, 8, 17 };
+    public static readonly int[] AllZoomLevels = { 15, 14, 16, 13, 12, 11, 10, 9, 8, 17, 18 };
 
     /// <summary>
     /// Quick check zoom levels for fast cache status verification.

--- a/src/WayfarerMobile/ViewModels/MainViewModel.cs
+++ b/src/WayfarerMobile/ViewModels/MainViewModel.cs
@@ -370,6 +370,33 @@ public partial class MainViewModel : BaseViewModel, IMapDisplayCallbacks, INavig
     public bool HasAltitude => CurrentLocation?.Altitude != null;
 
     /// <summary>
+    /// Gets or sets the current map zoom level.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ZoomLevelText))]
+    [NotifyPropertyChangedFor(nameof(HasZoomLevel))]
+    private int _currentZoomLevel = -1;
+
+    /// <summary>
+    /// Gets the zoom level text to display.
+    /// </summary>
+    public string ZoomLevelText => CurrentZoomLevel >= 0 ? $"Z{CurrentZoomLevel}" : string.Empty;
+
+    /// <summary>
+    /// Gets whether a valid zoom level is available.
+    /// </summary>
+    public bool HasZoomLevel => CurrentZoomLevel >= 0;
+
+    /// <summary>
+    /// Updates the current zoom level from viewport changes.
+    /// </summary>
+    /// <param name="zoomLevel">The current zoom level.</param>
+    public void UpdateZoomLevel(double zoomLevel)
+    {
+        CurrentZoomLevel = (int)Math.Round(zoomLevel);
+    }
+
+    /// <summary>
     /// Gets the cache health indicator color.
     /// Forwards to MapDisplayViewModel.
     /// </summary>

--- a/tests/WayfarerMobile.Tests/Unit/Services/CacheStatusServiceTests.cs
+++ b/tests/WayfarerMobile.Tests/Unit/Services/CacheStatusServiceTests.cs
@@ -200,7 +200,7 @@ public class CacheStatusServiceTests
     /// <summary>
     /// Zoom levels used for full status check (matches CacheStatusService.FullCheckZoomLevels).
     /// </summary>
-    private static readonly int[] FullCheckZoomLevels = { 15, 14, 16, 13, 12, 11, 10, 17 };
+    private static readonly int[] FullCheckZoomLevels = { 15, 14, 16, 13, 12, 11, 10, 9, 8, 17, 18 };
 
     #endregion
 
@@ -694,8 +694,8 @@ public class CacheStatusServiceTests
     [Fact]
     public void FullCheckZoomLevels_ContainsAllLevels()
     {
-        FullCheckZoomLevels.Should().BeEquivalentTo(new[] { 15, 14, 16, 13, 12, 11, 10, 17 },
-            "Full check should include 8 zoom levels for complete coverage");
+        FullCheckZoomLevels.Should().BeEquivalentTo(new[] { 15, 14, 16, 13, 12, 11, 10, 9, 8, 17, 18 },
+            "Full check should include 11 zoom levels for complete coverage");
     }
 
     /// <summary>
@@ -928,9 +928,9 @@ public class CacheStatusServiceTests
     {
         int radius = 5; // Default prefetch radius
         int tilesPerZoom = (2 * radius + 1) * (2 * radius + 1); // 121
-        int totalTiles = tilesPerZoom * FullCheckZoomLevels.Length; // 121 * 8 = 968
+        int totalTiles = tilesPerZoom * FullCheckZoomLevels.Length; // 121 * 11 = 1331
 
-        totalTiles.Should().Be(968, "Full check with radius 5 should check 968 tiles total");
+        totalTiles.Should().Be(1331, "Full check with radius 5 should check 1331 tiles total");
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Fixes #204 - Two enhancements to address blank tiles when zooming offline:

- **Display current map zoom level** in top overlay (e.g., "Z15") as diagnostic aid
- **Extend tile cache from z8-17 to z8-18** to cache highest detail tiles

## Changes

### Zoom Level Display
- Add `ZoomLevelText`/`HasZoomLevel` properties to `MainViewModel`
- Subscribe to `ViewportChanged` event with 500ms throttle
- Track subscribed navigator to prevent handler accumulation on repeated `OnAppearing` calls

### Tile Cache Extension
- Update `MaxZoomLevel` constant from 17 to 18
- Add z18 to `AllZoomLevels` array (now 11 levels total)
- Fix test array alignment (was missing z9, z8)

### Auto-Updated Services (via TileCacheConstants)
- `CacheOverlayService`: z18 circle on map
- `CacheStatusService`: z18 in status popup
- `AppDiagnosticService`: z18 in diagnostics
- `LiveTileCacheService`: z18 in prefetch
- `TileDownloadOrchestrator`: z18 in trip downloads

## Test plan
- [x] Build succeeds
- [x] All 91 CacheStatusServiceTests pass
- [x] Launch app, verify zoom level appears in top overlay (e.g., "Z15")
- [x] Zoom in/out, confirm display updates with ~500ms throttle
- [x] Open Diagnostics > Tile Cache, verify z18 appears in per-zoom breakdown
- [x] Show cache overlay on map, verify z18 coverage circle appears
- [ ] Test offline: zoom to z18, verify tiles load (after prefetch completes)