### PR TITLE
Fix offline banner hiding top info overlay (#207)

### DIFF
--- a/src/WayfarerMobile/App.xaml
+++ b/src/WayfarerMobile/App.xaml
@@ -36,6 +36,7 @@
             <converters:BoolToSyncBannerColorConverter x:Key="BoolToSyncBannerColorConverter" />
             <converters:VisibilityGatedImageSourceConverter x:Key="VisibilityGatedImageSourceConverter" />
             <converters:VisibilityGatedMauiAssetImageConverter x:Key="VisibilityGatedMauiAssetImageConverter" />
+            <converters:BoolToThicknessConverter x:Key="BoolToThicknessConverter" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/WayfarerMobile/Converters/BoolToThicknessConverter.cs
+++ b/src/WayfarerMobile/Converters/BoolToThicknessConverter.cs
@@ -1,0 +1,63 @@
+using System.Globalization;
+
+namespace WayfarerMobile.Converters;
+
+/// <summary>
+/// Converts a boolean value to a Thickness (margin/padding).
+/// Parameter format: "TrueMargins|FalseMargins" (e.g., "8,44,0,0|8,8,0,0")
+/// where margins are in the format "left,top,right,bottom".
+/// </summary>
+public class BoolToThicknessConverter : IValueConverter
+{
+    /// <summary>
+    /// Converts a boolean to a Thickness based on the parameter.
+    /// </summary>
+    /// <param name="value">The boolean value.</param>
+    /// <param name="targetType">The target type.</param>
+    /// <param name="parameter">Parameter in format "TrueMargins|FalseMargins".</param>
+    /// <param name="culture">The culture info.</param>
+    /// <returns>A Thickness value.</returns>
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not bool boolValue || parameter is not string paramString)
+            return new Thickness(0);
+
+        var parts = paramString.Split('|');
+        if (parts.Length != 2)
+            return new Thickness(0);
+
+        var marginString = boolValue ? parts[0] : parts[1];
+        return ParseThickness(marginString);
+    }
+
+    /// <summary>
+    /// Not implemented.
+    /// </summary>
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Parses a comma-separated string into a Thickness.
+    /// </summary>
+    /// <param name="marginString">String in format "left,top,right,bottom" or "all" or "horizontal,vertical".</param>
+    /// <returns>The parsed Thickness.</returns>
+    private static Thickness ParseThickness(string marginString)
+    {
+        var values = marginString.Split(',');
+
+        return values.Length switch
+        {
+            1 when double.TryParse(values[0], out var all) => new Thickness(all),
+            2 when double.TryParse(values[0], out var h) && double.TryParse(values[1], out var v) =>
+                new Thickness(h, v),
+            4 when double.TryParse(values[0], out var l) &&
+                   double.TryParse(values[1], out var t) &&
+                   double.TryParse(values[2], out var r) &&
+                   double.TryParse(values[3], out var b) =>
+                new Thickness(l, t, r, b),
+            _ => new Thickness(0)
+        };
+    }
+}

--- a/src/WayfarerMobile/MainPage.xaml
+++ b/src/WayfarerMobile/MainPage.xaml
@@ -42,7 +42,7 @@
                     <!-- Floating status overlay at top (2 rows, tappable to copy coords) -->
                     <Frame VerticalOptions="Start"
                            HorizontalOptions="Start"
-                           Margin="8,8,0,0"
+                           Margin="{Binding IsOffline, Converter={StaticResource BoolToThicknessConverter}, ConverterParameter='8,44,0,0|8,8,0,0'}"
                            Padding="12,6"
                            CornerRadius="16"
                            BackgroundColor="{AppThemeBinding Light={StaticResource White}, Dark={StaticResource Gray900}}"
@@ -110,7 +110,7 @@
                                  Command="{Binding MapDisplay.ResetNorthCommand}"
                                  VerticalOptions="Start"
                                  HorizontalOptions="End"
-                                 Margin="0,8,15,0"
+                                 Margin="{Binding IsOffline, Converter={StaticResource BoolToThicknessConverter}, ConverterParameter='0,44,15,0|0,8,15,0'}"
                                  WidthRequest="44"
                                  HeightRequest="44"
                                  CornerRadius="22"
@@ -169,7 +169,7 @@
                     <!-- Place Coordinate Edit Overlay (shown when editing place coordinates) -->
                     <Border VerticalOptions="Start"
                             HorizontalOptions="Fill"
-                            Margin="8,60,8,0"
+                            Margin="{Binding IsOffline, Converter={StaticResource BoolToThicknessConverter}, ConverterParameter='8,96,8,0|8,60,8,0'}"
                             Padding="16,12"
                             BackgroundColor="{AppThemeBinding Light=Black, Dark={StaticResource Gray900}}"
                             Opacity="0.95"


### PR DESCRIPTION
## Summary

- Add `BoolToThicknessConverter` to dynamically switch margins based on offline state
- Add `IsOffline` observable property to `MainViewModel` with connectivity change handling
- Update `MainPage.xaml` margins for status overlay, reset north button, and coordinate edit overlay

When offline, controls shift down 36px (banner ~30px + 6px gap) to remain visible below the offline banner.

Closes #207

## Test plan

- [x] Enable airplane mode and verify:
  - Offline banner is visible at top
  - Status overlay (top-left) is visible below the banner
  - Reset north button (top-right) is visible below the banner
- [x] Disable airplane mode and verify:
  - Banner hides
  - Controls return to original positions (8px from top)
- [ ] While offline, test coordinate edit mode:
  - Load a trip, edit a place's coordinates
  - Verify edit overlay is properly spaced below the banner