### PR TITLE
Fix downloaded trips not showing when offline (#212)

### DIFF
--- a/src/WayfarerMobile/ViewModels/Models/TripListItem.cs
+++ b/src/WayfarerMobile/ViewModels/Models/TripListItem.cs
@@ -314,6 +314,33 @@ public partial class TripListItem : ObservableObject
     }
 
     /// <summary>
+    /// Creates a trip list item from a downloaded entity only (offline mode).
+    /// </summary>
+    /// <param name="downloaded">The downloaded trip entity.</param>
+    public TripListItem(Data.Entities.DownloadedTripEntity downloaded)
+    {
+        ServerId = downloaded.ServerId;
+        Name = downloaded.Name;
+        UpdatedAt = downloaded.UpdatedAt;
+
+        // Construct bounding box from entity coordinates
+        BoundingBox = new BoundingBox
+        {
+            North = downloaded.BoundingBoxNorth,
+            South = downloaded.BoundingBoxSouth,
+            East = downloaded.BoundingBoxEast,
+            West = downloaded.BoundingBoxWest
+        };
+        if (!BoundingBox.IsValid)
+            BoundingBox = null;
+
+        _serverStatsText = null;
+        _downloadedEntity = downloaded;
+        _unifiedState = downloaded.UnifiedState;
+        _isDownloading = _unifiedState.IsDownloading();
+    }
+
+    /// <summary>
     /// Updates the unified state and related properties.
     /// Call this when receiving state change events.
     /// </summary>


### PR DESCRIPTION
## Summary

Fixes #212 - Downloaded trips were not displaying when the device was offline, even though they existed in local SQLite storage.

**Root Cause:** `MyTripsViewModel.LoadTripsAsync()` only displayed trips from the server response. When offline, the API call failed silently and the loop over server trips never executed, leaving the list empty. The downloaded trips from local DB were fetched but never used as a fallback.

**Solution:** Implement a deterministic two-path approach:
- Check connectivity state BEFORE making API call (not relying on failure)
- When online: use server data, merge with local download status (existing behavior)
- When offline: use local downloaded trips exclusively
- Handle network errors during online mode by falling back to offline mode

## Changes

- **`TripListItem.cs`**: Add offline-only constructor that creates items from `DownloadedTripEntity` without server data
- **`MyTripsViewModel.cs`**:
  - Add `IsOnline` observable property for connectivity awareness
  - Add `UpdateConnectivityState()` helper to check current network status
  - Add `OnConnectivityChanged()` event handler with auto-refresh when coming back online
  - Rewrite `LoadTripsAsync()` to use two-path approach (online vs offline)
  - Add `LoadFromLocalOnlyAsync()` fallback for network failures
  - Subscribe/unsubscribe to `Connectivity.ConnectivityChanged` in lifecycle methods

## Test plan

- [x] Download a trip while online
- [x] Enable airplane mode
- [x] Navigate to My Trips tab
- [x] **Expected**: Downloaded trips appear with correct status icons
- [x] Tap "Load to Map" on a downloaded trip
- [x] **Expected**: Trip loads successfully
- [x] Disable airplane mode
- [x] **Expected**: Trips auto-refresh with server data

### Edge cases to verify
- Offline with no downloaded trips: should show empty list (no error)
- Partially downloaded (MetadataOnly): should appear in list
- Paused downloads: should appear (they have metadata)
- ServerOnly trips: should NOT appear when offline
- Network timeout during online mode: should fallback to local data