### PR TITLE
fix: use app filesystem storage for trip downloads

### DIFF
--- a/src/WayfarerMobile.Core/Interfaces/IStorageSpaceProvider.cs
+++ b/src/WayfarerMobile.Core/Interfaces/IStorageSpaceProvider.cs
@@ -1,0 +1,15 @@
+namespace WayfarerMobile.Core.Interfaces;
+
+/// <summary>
+/// Provides available storage information for the filesystem containing a path.
+/// </summary>
+public interface IStorageSpaceProvider
+{
+    /// <summary>
+    /// Attempts to get the bytes available to the current application.
+    /// </summary>
+    /// <param name="path">A path on the filesystem to inspect.</param>
+    /// <param name="availableBytes">The available bytes when successful.</param>
+    /// <returns>True when storage information was retrieved; otherwise false.</returns>
+    bool TryGetAvailableBytes(string path, out long availableBytes);
+}

--- a/src/WayfarerMobile.Core/Interfaces/IStorageSpaceService.cs
+++ b/src/WayfarerMobile.Core/Interfaces/IStorageSpaceService.cs
@@ -1,0 +1,13 @@
+namespace WayfarerMobile.Core.Interfaces;
+
+/// <summary>
+/// Evaluates whether a filesystem has enough available storage.
+/// </summary>
+public interface IStorageSpaceService
+{
+    /// <summary>
+    /// Checks whether the filesystem containing a path meets a byte requirement.
+    /// Storage lookup failures fail open.
+    /// </summary>
+    bool HasSufficientStorage(string path, long requiredBytes);
+}

--- a/src/WayfarerMobile.Core/Services/StorageSpaceService.cs
+++ b/src/WayfarerMobile.Core/Services/StorageSpaceService.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Logging;
+using WayfarerMobile.Core.Interfaces;
+
+namespace WayfarerMobile.Core.Services;
+
+/// <summary>
+/// Applies storage thresholds to platform-provided filesystem information.
+/// </summary>
+public sealed class StorageSpaceService : IStorageSpaceService
+{
+    private readonly IStorageSpaceProvider _provider;
+    private readonly ILogger<StorageSpaceService> _logger;
+
+    public StorageSpaceService(
+        IStorageSpaceProvider provider,
+        ILogger<StorageSpaceService> logger)
+    {
+        _provider = provider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public bool HasSufficientStorage(string path, long requiredBytes)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentOutOfRangeException.ThrowIfNegative(requiredBytes);
+
+        try
+        {
+            if (!_provider.TryGetAvailableBytes(path, out var availableBytes))
+            {
+                _logger.LogWarning(
+                    "Could not determine available storage for {StoragePath}; allowing operation",
+                    path);
+                return true;
+            }
+
+            if (availableBytes < requiredBytes)
+            {
+                _logger.LogInformation(
+                    "Insufficient storage for {StoragePath}: {AvailableBytes} bytes available, {RequiredBytes} bytes required",
+                    path,
+                    availableBytes,
+                    requiredBytes);
+                return false;
+            }
+
+            _logger.LogDebug(
+                "Available storage for {StoragePath}: {AvailableBytes} bytes available, {RequiredBytes} bytes required",
+                path,
+                availableBytes,
+                requiredBytes);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to determine available storage for {StoragePath}; allowing operation",
+                path);
+            return true;
+        }
+    }
+}

--- a/src/WayfarerMobile/MauiProgram.cs
+++ b/src/WayfarerMobile/MauiProgram.cs
@@ -154,14 +154,17 @@ public static class MauiProgram
         services.AddSingleton<ILocationBridge, WayfarerMobile.Platforms.Android.Services.LocationBridge>();
         services.AddSingleton<IWakeLockService, WayfarerMobile.Platforms.Android.Services.WakeLockService>();
         services.AddSingleton<ILocalNotificationService, WayfarerMobile.Platforms.Android.Services.LocalNotificationService>();
+        services.AddSingleton<IStorageSpaceProvider, WayfarerMobile.Platforms.Android.Services.StorageSpaceProvider>();
 #elif IOS
         services.AddSingleton<ILocationBridge, WayfarerMobile.Platforms.iOS.Services.LocationBridge>();
         services.AddSingleton<IWakeLockService, WayfarerMobile.Platforms.iOS.Services.WakeLockService>();
         services.AddSingleton<ILocalNotificationService, WayfarerMobile.Platforms.iOS.Services.LocalNotificationService>();
+        services.AddSingleton<IStorageSpaceProvider, WayfarerMobile.Platforms.iOS.Services.StorageSpaceProvider>();
 #endif
 
         // Infrastructure Services
         services.AddSingleton<DatabaseService>();
+        services.AddSingleton<IStorageSpaceService, StorageSpaceService>();
 
         // Database connection factory for repositories
         services.AddSingleton<Func<Task<SQLiteAsyncConnection>>>(sp =>

--- a/src/WayfarerMobile/Platforms/Android/Services/StorageSpaceProvider.cs
+++ b/src/WayfarerMobile/Platforms/Android/Services/StorageSpaceProvider.cs
@@ -1,0 +1,18 @@
+using Android.OS;
+using WayfarerMobile.Core.Interfaces;
+
+namespace WayfarerMobile.Platforms.Android.Services;
+
+/// <summary>
+/// Reads storage information for the Android filesystem containing a path.
+/// </summary>
+public sealed class StorageSpaceProvider : IStorageSpaceProvider
+{
+    /// <inheritdoc/>
+    public bool TryGetAvailableBytes(string path, out long availableBytes)
+    {
+        using var statistics = new StatFs(path);
+        availableBytes = statistics.AvailableBytes;
+        return true;
+    }
+}

--- a/src/WayfarerMobile/Platforms/iOS/Services/StorageSpaceProvider.cs
+++ b/src/WayfarerMobile/Platforms/iOS/Services/StorageSpaceProvider.cs
@@ -1,0 +1,24 @@
+using Foundation;
+using WayfarerMobile.Core.Interfaces;
+
+namespace WayfarerMobile.Platforms.iOS.Services;
+
+/// <summary>
+/// Reads storage information for the iOS filesystem containing a path.
+/// </summary>
+public sealed class StorageSpaceProvider : IStorageSpaceProvider
+{
+    /// <inheritdoc/>
+    public bool TryGetAvailableBytes(string path, out long availableBytes)
+    {
+        var attributes = NSFileManager.DefaultManager.GetFileSystemAttributes(path, out var error);
+        if (attributes == null || error != null)
+        {
+            availableBytes = 0;
+            return false;
+        }
+
+        availableBytes = checked((long)attributes.FreeSize);
+        return true;
+    }
+}

--- a/src/WayfarerMobile/Services/DownloadNotificationService.cs
+++ b/src/WayfarerMobile/Services/DownloadNotificationService.cs
@@ -11,16 +11,19 @@ public class DownloadNotificationService : IDownloadNotificationService
 {
     private readonly ILogger<DownloadNotificationService> _logger;
     private readonly IToastService _toastService;
+    private readonly IStorageSpaceService _storageSpaceService;
 
     /// <summary>
     /// Creates a new instance of DownloadNotificationService.
     /// </summary>
     public DownloadNotificationService(
         ILogger<DownloadNotificationService> logger,
-        IToastService toastService)
+        IToastService toastService,
+        IStorageSpaceService storageSpaceService)
     {
         _logger = logger;
         _toastService = toastService;
+        _storageSpaceService = storageSpaceService;
     }
 
     /// <inheritdoc/>
@@ -89,45 +92,29 @@ public class DownloadNotificationService : IDownloadNotificationService
     /// <inheritdoc/>
     public async Task<bool> CheckStorageBeforeDownloadAsync(double requiredMb)
     {
-        try
+        // Preserve the existing 1 GB buffer used by the pre-download warning.
+        var requiredWithBufferMb = requiredMb + 1024;
+        var requiredBytes = checked((long)Math.Ceiling(requiredWithBufferMb * 1024 * 1024));
+        if (_storageSpaceService.HasSufficientStorage(FileSystem.CacheDirectory, requiredBytes))
         {
-            // Get available space (platform-specific)
-            var cacheDir = FileSystem.CacheDirectory;
-            var driveInfo = new DriveInfo(Path.GetPathRoot(cacheDir) ?? cacheDir);
-            var availableMb = driveInfo.AvailableFreeSpace / (1024.0 * 1024.0);
-
-            // Require at least 1GB buffer
-            var requiredWithBuffer = requiredMb + 1024;
-
-            if (availableMb < requiredWithBuffer)
-            {
-                var page = Application.Current?.Windows.FirstOrDefault()?.Page;
-                if (page != null)
-                {
-                    var availableText = availableMb >= 1000
-                        ? $"{availableMb / 1000:F1} GB"
-                        : $"{availableMb:F0} MB";
-                    var requiredText = requiredMb >= 1000
-                        ? $"{requiredMb / 1000:F1} GB"
-                        : $"{requiredMb:F0} MB";
-
-                    await page.DisplayAlertAsync(
-                        "Insufficient Storage",
-                        $"This download requires approximately {requiredText}, but only {availableText} is available.\n\n" +
-                        "Please free up some space and try again.",
-                        "OK");
-                }
-                return false;
-            }
-
             return true;
         }
-        catch (Exception ex)
+
+        var page = Application.Current?.Windows.FirstOrDefault()?.Page;
+        if (page != null)
         {
-            _logger.LogWarning(ex, "Failed to check storage space");
-            // If we can't check, proceed anyway
-            return true;
+            var requiredText = requiredMb >= 1000
+                ? $"{requiredMb / 1000:F1} GB"
+                : $"{requiredMb:F0} MB";
+
+            await page.DisplayAlertAsync(
+                "Insufficient Storage",
+                $"This download requires approximately {requiredText} plus a 1 GB safety buffer.\n\n" +
+                "Please free up some space and try again.",
+                "OK");
         }
+
+        return false;
     }
 
     /// <inheritdoc/>

--- a/src/WayfarerMobile/Services/TileDownloadService.cs
+++ b/src/WayfarerMobile/Services/TileDownloadService.cs
@@ -1,4 +1,3 @@
-using System.Security;
 using Microsoft.Extensions.Logging;
 using WayfarerMobile.Core.Interfaces;
 using WayfarerMobile.Core.Models;
@@ -18,6 +17,7 @@ namespace WayfarerMobile.Services;
 public sealed class TileDownloadService : ITileDownloadService, IDisposable
 {
     private readonly ISettingsService _settingsService;
+    private readonly IStorageSpaceService _storageSpaceService;
     private readonly ILogger<TileDownloadService> _logger;
     private readonly HttpClient _httpClient;
 
@@ -45,9 +45,11 @@ public sealed class TileDownloadService : ITileDownloadService, IDisposable
     /// </summary>
     public TileDownloadService(
         ISettingsService settingsService,
+        IStorageSpaceService storageSpaceService,
         ILogger<TileDownloadService> logger)
     {
         _settingsService = settingsService;
+        _storageSpaceService = storageSpaceService;
         _logger = logger;
 
         // Initialize shared HttpClient with appropriate timeout
@@ -258,37 +260,8 @@ public sealed class TileDownloadService : ITileDownloadService, IDisposable
     /// <inheritdoc/>
     public bool HasSufficientStorage(long requiredMB = 50)
     {
-        try
-        {
-            var cacheDir = FileSystem.CacheDirectory;
-            var pathRoot = Path.GetPathRoot(cacheDir);
-            if (string.IsNullOrEmpty(pathRoot))
-            {
-                _logger.LogWarning("Could not determine path root, assuming sufficient storage");
-                return true;
-            }
-
-            var driveInfo = new DriveInfo(pathRoot);
-            var freeSpaceMB = driveInfo.AvailableFreeSpace / (1024 * 1024);
-
-            _logger.LogDebug("Available storage: {FreeSpace} MB, required: {Required} MB", freeSpaceMB, requiredMB);
-            return freeSpaceMB >= requiredMB;
-        }
-        catch (IOException ex)
-        {
-            _logger.LogWarning(ex, "I/O error checking storage, assuming sufficient");
-            return true;
-        }
-        catch (SecurityException ex)
-        {
-            _logger.LogWarning(ex, "Security error checking storage, assuming sufficient");
-            return true;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Unexpected error checking storage, assuming sufficient");
-            return true;
-        }
+        var requiredBytes = checked(requiredMB * 1024 * 1024);
+        return _storageSpaceService.HasSufficientStorage(FileSystem.CacheDirectory, requiredBytes);
     }
 
     /// <inheritdoc/>

--- a/tests/WayfarerMobile.Tests/Unit/Services/StorageSpaceServiceTests.cs
+++ b/tests/WayfarerMobile.Tests/Unit/Services/StorageSpaceServiceTests.cs
@@ -43,6 +43,7 @@ public class StorageSpaceServiceTests
         var service = CreateService();
 
         service.HasSufficientStorage(CachePath, RequiredBytes).Should().BeFalse();
+        VerifyLogLevel(LogLevel.Information);
     }
 
     [Fact]
@@ -75,6 +76,7 @@ public class StorageSpaceServiceTests
         var service = CreateService();
 
         service.HasSufficientStorage(CachePath, RequiredBytes).Should().BeTrue();
+        VerifyLogLevel(LogLevel.Warning);
     }
 
     [Fact]
@@ -87,10 +89,23 @@ public class StorageSpaceServiceTests
         var service = CreateService();
 
         service.HasSufficientStorage(CachePath, RequiredBytes).Should().BeTrue();
+        VerifyLogLevel(LogLevel.Warning);
     }
 
     private StorageSpaceService CreateService()
     {
         return new StorageSpaceService(_provider.Object, _logger.Object);
+    }
+
+    private void VerifyLogLevel(LogLevel level)
+    {
+        _logger.Verify(
+            logger => logger.Log(
+                level,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((_, _) => true),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 }

--- a/tests/WayfarerMobile.Tests/Unit/Services/StorageSpaceServiceTests.cs
+++ b/tests/WayfarerMobile.Tests/Unit/Services/StorageSpaceServiceTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using WayfarerMobile.Core.Interfaces;
+using WayfarerMobile.Core.Services;
+
+namespace WayfarerMobile.Tests.Unit.Services;
+
+public class StorageSpaceServiceTests
+{
+    private const string CachePath = "/app/cache";
+    private const long RequiredBytes = 50L * 1024 * 1024;
+
+    private readonly Mock<IStorageSpaceProvider> _provider = new();
+    private readonly Mock<ILogger<StorageSpaceService>> _logger = new();
+
+    [Fact]
+    public void HasSufficientStorage_WhenAvailableSpaceExceedsRequirement_ReturnsTrue()
+    {
+        _provider
+            .Setup(provider => provider.TryGetAvailableBytes(CachePath, out It.Ref<long>.IsAny))
+            .Returns((string _, out long availableBytes) =>
+            {
+                availableBytes = RequiredBytes + 1;
+                return true;
+            });
+
+        var service = CreateService();
+
+        service.HasSufficientStorage(CachePath, RequiredBytes).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasSufficientStorage_WhenAvailableSpaceIsBelowRequirement_ReturnsFalse()
+    {
+        _provider
+            .Setup(provider => provider.TryGetAvailableBytes(CachePath, out It.Ref<long>.IsAny))
+            .Returns((string _, out long availableBytes) =>
+            {
+                availableBytes = RequiredBytes - 1;
+                return true;
+            });
+
+        var service = CreateService();
+
+        service.HasSufficientStorage(CachePath, RequiredBytes).Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasSufficientStorage_WhenAvailableSpaceEqualsRequirement_ReturnsTrue()
+    {
+        _provider
+            .Setup(provider => provider.TryGetAvailableBytes(CachePath, out It.Ref<long>.IsAny))
+            .Returns((string _, out long availableBytes) =>
+            {
+                availableBytes = RequiredBytes;
+                return true;
+            });
+
+        var service = CreateService();
+
+        service.HasSufficientStorage(CachePath, RequiredBytes).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasSufficientStorage_WhenProviderCannotDetermineSpace_FailsOpen()
+    {
+        _provider
+            .Setup(provider => provider.TryGetAvailableBytes(CachePath, out It.Ref<long>.IsAny))
+            .Returns((string _, out long availableBytes) =>
+            {
+                availableBytes = 0;
+                return false;
+            });
+
+        var service = CreateService();
+
+        service.HasSufficientStorage(CachePath, RequiredBytes).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasSufficientStorage_WhenProviderThrows_FailsOpen()
+    {
+        _provider
+            .Setup(provider => provider.TryGetAvailableBytes(CachePath, out It.Ref<long>.IsAny))
+            .Throws<IOException>();
+
+        var service = CreateService();
+
+        service.HasSufficientStorage(CachePath, RequiredBytes).Should().BeTrue();
+    }
+
+    private StorageSpaceService CreateService()
+    {
+        return new StorageSpaceService(_provider.Object, _logger.Object);
+    }
+}


### PR DESCRIPTION
## Summary
- query available storage for the filesystem containing the app cache path
- use Android `StatFs` and iOS filesystem attributes through a shared provider
- preserve the existing thresholds and fail-open behavior
- add focused threshold, failure, and diagnostics tests

## Root cause
The previous Android check reduced the app cache path under `/data` to `/` and queried the root filesystem, which can report misleading free space on newer devices.

## Validation
- `dotnet test tests/WayfarerMobile.Tests/WayfarerMobile.Tests.csproj --no-restore` (2,395 passed)
- `dotnet build src/WayfarerMobile/WayfarerMobile.csproj -f net10.0-android --no-restore`
- `dotnet build src/WayfarerMobile/WayfarerMobile.csproj -f net10.0-ios --no-restore`

Manual Samsung Galaxy S26 Ultra verification remains part of release-candidate acceptance.

Closes #229