### PR TITLE
fix: harden formal release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.2.0
+
+### 2026-06-20
+- **Feature: Search private trips (#228, PR #231)**
+  - Added local, case-insensitive trip-name search to the My Trips tab
+  - Preserved download-status grouping while hiding groups with no matches
+  - Kept download and sync callbacks connected to canonical trip items while filtering
+- **Fix: Correct storage checks for trip downloads (#229, PR #230)**
+  - Android now checks available bytes on the app cache filesystem using `StatFs`
+  - iOS uses filesystem attributes for the supplied cache path
+  - Preserved existing storage thresholds and fail-open behavior
+  - Added release-visible diagnostics with checked path, available bytes, and required bytes
+- **Chore: Harden formal release workflow**
+  - Require the target changelog heading before creating a release tag
+  - Require local `main` to match `origin/main`
+  - Use safe local branch deletion after the version-bump PR is merged
+
 ## 1.1.0
 
 ### 2026-02-22

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -29,6 +29,7 @@ from typing import Optional
 # ---------------------------------------------------------------------------
 
 CSPROJ_RELATIVE = os.path.join("src", "WayfarerMobile", "WayfarerMobile.csproj")
+CHANGELOG_RELATIVE = "CHANGELOG.md"
 REPO_NAME = "stef-k/WayfarerMobile"
 CHANGELOG_URL = f"https://github.com/{REPO_NAME}/blob/main/CHANGELOG.md"
 
@@ -88,7 +89,7 @@ class ReleaseState:
 
         if self.step.value >= Step.BRANCH_CREATED.value and self.step.value < Step.LOCAL_BRANCH_DELETED.value:
             cmds.append("git checkout main")
-            cmds.append(f"git branch -D {self.branch_name}")
+            cmds.append(f"git branch -d {self.branch_name}")
 
         if self.step.value >= Step.CSPROJ_MODIFIED.value and self.step.value < Step.MERGED.value:
             cmds.append(f"git checkout main -- {CSPROJ_RELATIVE}")
@@ -187,15 +188,15 @@ def preflight(repo_root: Path) -> Path:
     if not csproj.exists():
         fatal(f".csproj not found at {csproj}")
 
-    # 6. Warn if behind remote
+    # 6. Require local main to match remote main
     run(["git", "fetch", "origin", "main"], check=False)
     behind = run_output(["git", "rev-list", "--count", "HEAD..origin/main"])
     if behind and int(behind) > 0:
-        print(f"Warning: main is {behind} commit(s) behind origin/main.")
-        ans = confirm("Continue anyway? [y/n] ")
-        if ans != "y":
-            print("Aborted.")
-            sys.exit(0)
+        fatal(f"main is {behind} commit(s) behind origin/main. Pull before releasing.")
+
+    ahead = run_output(["git", "rev-list", "--count", "origin/main..HEAD"])
+    if ahead and int(ahead) > 0:
+        fatal(f"main is {ahead} commit(s) ahead of origin/main. Push or reconcile before releasing.")
 
     return csproj
 
@@ -267,6 +268,23 @@ def validate_version(new_ver: str, current_display: str, latest_tag: Optional[st
     existing = run(["git", "tag", "--list", new_ver], check=False)
     if existing.stdout.strip():
         return f"Tag '{new_ver}' already exists."
+
+    return None
+
+
+def validate_changelog_version(repo_root: Path, version: str) -> Optional[str]:
+    """Require the release heading to be committed before tagging."""
+    changelog = repo_root / CHANGELOG_RELATIVE
+    if not changelog.exists():
+        return f"{CHANGELOG_RELATIVE} does not exist."
+
+    content = changelog.read_text(encoding="utf-8")
+    heading = re.compile(rf"^##\s+{re.escape(version)}\s*$", re.MULTILINE)
+    if not heading.search(content):
+        return (
+            f"{CHANGELOG_RELATIVE} must contain a '## {version}' heading "
+            "before running the release."
+        )
 
     return None
 
@@ -369,9 +387,13 @@ def post_merge_cleanup(branch: str) -> None:
     _state.step = Step.ON_MAIN
     run(["git", "pull", "origin", "main"])
     # Delete local branch (may already be deleted by --delete-branch in merge).
-    result = run(["git", "branch", "-D", branch], check=False)
-    if result.returncode == 0:
-        _state.step = Step.LOCAL_BRANCH_DELETED
+    result = run(["git", "branch", "-d", branch], check=False)
+    if result.returncode != 0:
+        fatal(
+            f"Local branch '{branch}' could not be deleted safely. "
+            "Verify it is fully merged before deleting it."
+        )
+    _state.step = Step.LOCAL_BRANCH_DELETED
 
 
 def create_tag(version: str) -> None:
@@ -464,6 +486,10 @@ def main() -> None:
     # --- Version prompt loop ---
     while True:
         new_ver = prompt_version(display_ver, latest_tag)
+        changelog_error = validate_changelog_version(repo_root, new_ver)
+        if changelog_error:
+            print(f"  {changelog_error}")
+            continue
         new_build = build_num + 1
         branch = f"chore/version-bump-{new_ver}"
 
@@ -534,16 +560,17 @@ def main() -> None:
     _state.step = Step.RELEASE_CREATED
 
     # --- Success ---
-    print("\n=== Release Complete ===")
+    print("\n=== Draft Release Created ===")
     print(f"  Version : {new_ver}")
     print(f"  Build   : {new_build}")
     print(f"  Tag     : {new_ver}")
     print(f"  Release : {release_url}")
     print()
     print("Next steps:")
-    print(f"  1. Update CHANGELOG.md with {new_ver} entries")
-    print(f"  2. Review and publish the draft release on GitHub")
-    print(f"  3. Build and attach the APK to the release")
+    print("  1. Build and install the release APK")
+    print("  2. Complete device acceptance testing")
+    print("  3. Attach the APK to the draft release")
+    print("  4. Review and publish the draft release on GitHub")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_release.py
+++ b/scripts/tests/test_release.py
@@ -1,0 +1,54 @@
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "release.py"
+SPEC = importlib.util.spec_from_file_location("wayfarer_release", SCRIPT_PATH)
+release = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = release
+SPEC.loader.exec_module(release)
+
+
+class ValidateChangelogVersionTests(unittest.TestCase):
+    def test_accepts_exact_release_heading(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "CHANGELOG.md").write_text(
+                "# Changelog\n\n## 1.2.0\n\n- Entry\n",
+                encoding="utf-8",
+            )
+
+            self.assertIsNone(release.validate_changelog_version(root, "1.2.0"))
+
+    def test_rejects_missing_release_heading(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "CHANGELOG.md").write_text(
+                "# Changelog\n\n## 1.1.0\n",
+                encoding="utf-8",
+            )
+
+            error = release.validate_changelog_version(root, "1.2.0")
+
+            self.assertIn("## 1.2.0", error)
+
+
+class CleanupInstructionsTests(unittest.TestCase):
+    def test_local_branch_cleanup_is_non_forcing(self):
+        state = release.ReleaseState(
+            step=release.Step.BRANCH_CREATED,
+            branch_name="chore/version-bump-1.2.0",
+        )
+
+        commands = state.cleanup_instructions()
+
+        self.assertIn("git branch -d chore/version-bump-1.2.0", commands)
+        self.assertNotIn("git branch -D chore/version-bump-1.2.0", commands)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- prepare the 1.2.0 changelog for #228 and #229
- require a committed target-version changelog heading before release tagging
- require local main to match origin/main
- replace forced local branch deletion with safe deletion
- clarify that the script creates a draft release pending APK/device acceptance
- add Python unit tests for changelog validation and cleanup safety

## Validation
- `python -m unittest discover -s scripts/tests -v`
- `python -m py_compile scripts/release.py`
- `dotnet test tests/WayfarerMobile.Tests/WayfarerMobile.Tests.csproj --no-restore` (2,400 passed)