### PR TITLE
fix: align release branch naming with policy

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -491,7 +491,7 @@ def main() -> None:
             print(f"  {changelog_error}")
             continue
         new_build = build_num + 1
-        branch = f"chore/version-bump-{new_ver}"
+        branch = f"feature/version-bump-{new_ver}"
 
         choice = show_confirmation(display_ver, build_num, new_ver, new_build, branch)
         if choice == "y":

--- a/scripts/tests/test_release.py
+++ b/scripts/tests/test_release.py
@@ -41,13 +41,13 @@ class CleanupInstructionsTests(unittest.TestCase):
     def test_local_branch_cleanup_is_non_forcing(self):
         state = release.ReleaseState(
             step=release.Step.BRANCH_CREATED,
-            branch_name="chore/version-bump-1.2.0",
+            branch_name="feature/version-bump-1.2.0",
         )
 
         commands = state.cleanup_instructions()
 
-        self.assertIn("git branch -d chore/version-bump-1.2.0", commands)
-        self.assertNotIn("git branch -D chore/version-bump-1.2.0", commands)
+        self.assertIn("git branch -d feature/version-bump-1.2.0", commands)
+        self.assertNotIn("git branch -D feature/version-bump-1.2.0", commands)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- create version-bump branches under the required feature/ namespace
- update release helper coverage

## Validation
- python -m unittest discover -s scripts/tests -v