### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/src/WayfarerMobile/WayfarerMobile.csproj
+++ b/src/WayfarerMobile/WayfarerMobile.csproj
@@ -21,8 +21,8 @@
 		<ApplicationId>me.stefk.wayfarermobile</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
-		<ApplicationVersion>2</ApplicationVersion>
+		<ApplicationDisplayVersion>1.2.0</ApplicationDisplayVersion>
+		<ApplicationVersion>3</ApplicationVersion>
 
 		<!-- Platform versions -->
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>


### PR DESCRIPTION
## Summary
- Bump `ApplicationDisplayVersion` to `1.2.0`
- Auto-increment `ApplicationVersion` (build number)

Automated by `scripts/release.py`.