### PR TITLE
fix: make release branch cleanup idempotent

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -386,13 +386,20 @@ def post_merge_cleanup(branch: str) -> None:
     run(["git", "checkout", "main"])
     _state.step = Step.ON_MAIN
     run(["git", "pull", "origin", "main"])
-    # Delete local branch (may already be deleted by --delete-branch in merge).
-    result = run(["git", "branch", "-d", branch], check=False)
-    if result.returncode != 0:
-        fatal(
-            f"Local branch '{branch}' could not be deleted safely. "
-            "Verify it is fully merged before deleting it."
-        )
+
+    # gh pr merge --delete-branch may already have deleted the local branch.
+    local_ref = f"refs/heads/{branch}"
+    branch_exists = run(
+        ["git", "show-ref", "--verify", "--quiet", local_ref],
+        check=False,
+    )
+    if branch_exists.returncode == 0:
+        result = run(["git", "branch", "-d", branch], check=False)
+        if result.returncode != 0:
+            fatal(
+                f"Local branch '{branch}' could not be deleted safely. "
+                "Verify it is fully merged before deleting it."
+            )
     _state.step = Step.LOCAL_BRANCH_DELETED
 
 

--- a/scripts/tests/test_release.py
+++ b/scripts/tests/test_release.py
@@ -3,6 +3,8 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
 
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "release.py"
@@ -48,6 +50,35 @@ class CleanupInstructionsTests(unittest.TestCase):
 
         self.assertIn("git branch -d feature/version-bump-1.2.0", commands)
         self.assertNotIn("git branch -D feature/version-bump-1.2.0", commands)
+
+    @patch.object(release, "run")
+    def test_post_merge_cleanup_accepts_already_deleted_local_branch(self, run_mock):
+        run_mock.side_effect = [
+            CompletedProcess(["git", "checkout", "main"], 0),
+            CompletedProcess(["git", "pull", "origin", "main"], 0),
+            CompletedProcess(["git", "show-ref"], 1),
+        ]
+
+        release.post_merge_cleanup("feature/version-bump-1.2.0")
+
+        self.assertEqual(release.Step.LOCAL_BRANCH_DELETED, release._state.step)
+        self.assertEqual(3, run_mock.call_count)
+
+    @patch.object(release, "run")
+    def test_post_merge_cleanup_safely_deletes_existing_local_branch(self, run_mock):
+        run_mock.side_effect = [
+            CompletedProcess(["git", "checkout", "main"], 0),
+            CompletedProcess(["git", "pull", "origin", "main"], 0),
+            CompletedProcess(["git", "show-ref"], 0),
+            CompletedProcess(["git", "branch", "-d"], 0),
+        ]
+
+        release.post_merge_cleanup("feature/version-bump-1.2.0")
+
+        run_mock.assert_called_with(
+            ["git", "branch", "-d", "feature/version-bump-1.2.0"],
+            check=False,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- tolerate the version-bump branch already being removed by gh pr merge --delete-branch
- retain safe deletion when the local branch still exists
- add regression tests for both cleanup paths

## Validation
- python -m unittest discover -s scripts/tests -v
- python -m py_compile scripts/release.py